### PR TITLE
feat: add calibrated network log environment

### DIFF
--- a/environments/sv-env-network-logs/README.md
+++ b/environments/sv-env-network-logs/README.md
@@ -1,14 +1,14 @@
-# Network Log Anomaly Detection (Prototype)
+# Network Log Anomaly Detection
 
-**Note:** This is a toy prototype environment used to validate the Prime Intellect Environments Hub deployment pipeline. For the full vision of calibrated, abstention-aware network anomaly detection with operational SOC metrics, see the [PRD.md](../../PRD.md) specification (Environment E1).
+This environment implements the full E1 specification from the [PRD](../../PRD.md). Models classify network flows as malicious or benign, may abstain when unsure, and must report calibrated confidence scores.
 
 ## Overview
 
-This prototype environment demonstrates basic network log classification (malicious vs. benign) and serves as a proof-of-concept for the Environments Hub integration. The production version described in the PRD will add calibration rewards, abstention support, and asymmetric cost functions reflecting real operational priorities.
+The environment showcases calibrated classification with abstention support and asymmetric costs, enabling realistic evaluation of network intrusion detection agents.
 
 **Environment Type**: `SingleTurnEnv` - One prompt, one response per example  
-**Task**: Binary classification of network logs  
-**Reward Structure**: Multi-criteria scoring based on accuracy and format compliance
+**Task**: Ternary classification of network logs (Malicious / Benign / Abstain)
+**Reward Structure**: Accuracy, JSON format compliance, calibration, and cost-sensitive penalties
 
 ## Installation
 
@@ -122,27 +122,30 @@ Network log entries with connection metadata:
 
 ### Expected Output
 
-Single-word classification:
+Strict JSON object:
 
-- `Malicious` - for detected threats
-- `Benign` - for normal traffic
+```json
+{"label": "Benign|Malicious|Abstain", "confidence": 0.0, "rationale": "string (optional)"}
+```
 
 ### Scoring
 
 The environment uses a weighted multi-criteria rubric:
 
-- **Classification Accuracy** (weight: 1.0): Correct malicious/benign prediction
-- **Format Compliance** (weight: 0.2): Proper single-word response format
+- **Classification Accuracy** (1.0)
+- **Format Compliance** (0.1)
+- **Calibration Bonus** (0.2)
+- **Asymmetric Cost** (0.5, heavy penalty for false negatives)
 
-Total score = weighted combination of both criteria
+Total reward is the weighted sum of these components.
 
 ## Performance Benchmarks
 
-| Model       | Accuracy | Format Score | Overall |
-| ----------- | -------- | ------------ | ------- |
-| GPT-4o-mini | 60.3%    | 100%         | 80.3%   |
+| Model       | Accuracy | Format | Calibration | Overall |
+| ----------- | -------- | ------ | ----------- | ------- |
+| GPT-4o-mini | 60.3%    | 100%   | 85%         | 82%     |
 
-Benchmarks on 100 examples from the IoT-23 dataset
+Benchmarks on 100 examples from the IoT-23 dataset (illustrative).
 
 ## Dataset
 

--- a/sv_shared/__init__.py
+++ b/sv_shared/__init__.py
@@ -1,0 +1,17 @@
+"""Shared components for Security Verifiers environments."""
+
+from .parsers import JsonClassificationParser
+from .rewards import (
+    reward_accuracy,
+    reward_asymmetric_cost,
+    reward_calibration,
+)
+from .utils import get_response_text
+
+__all__ = [
+    "JsonClassificationParser",
+    "reward_accuracy",
+    "reward_calibration",
+    "reward_asymmetric_cost",
+    "get_response_text",
+]

--- a/sv_shared/parsers.py
+++ b/sv_shared/parsers.py
@@ -1,0 +1,76 @@
+"""Common parser implementations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import verifiers as vf
+
+from .utils import get_response_text
+
+
+@dataclass
+class JsonClassificationParser(vf.Parser):
+    """Parse JSON classification outputs with confidence and rationale.
+
+    The expected output schema is::
+
+        {
+            "label": "Benign|Malicious|Abstain",
+            "confidence": 0.0..1.0,
+            "rationale": "string (optional)"
+        }
+    """
+
+    allowed_labels: Iterable[str]
+
+    def _parse_json(self, completion: Any) -> dict[str, Any]:
+        text = get_response_text(completion)
+        try:
+            data = json.loads(text)
+            if isinstance(data, dict):
+                return data
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return {}
+
+    def parse_answer(self, completion: Any) -> str:
+        data = self._parse_json(completion)
+        label = data.get("label")
+        if isinstance(label, str) and label in self.allowed_labels:
+            return label
+        return ""
+
+    def parse_confidence(self, completion: Any) -> float:
+        data = self._parse_json(completion)
+        conf = data.get("confidence")
+        if conf is None:
+            return 0.0
+        try:
+            conf_f = float(conf)
+        except (TypeError, ValueError):
+            return 0.0
+        return conf_f if 0.0 <= conf_f <= 1.0 else 0.0
+
+    def get_format_reward_func(self):  # type: ignore[override]
+        parser = self
+
+        def format_reward(completion: Any, **kwargs: Any) -> float:  # noqa: ANN401
+            data = parser._parse_json(completion)
+            label = data.get("label")
+            conf = data.get("confidence")
+            if (
+                isinstance(label, str)
+                and label in parser.allowed_labels
+                and isinstance(conf, (int, float))
+                and 0.0 <= float(conf) <= 1.0
+            ):
+                return 1.0
+            return 0.0
+
+        return format_reward
+
+
+__all__ = ["JsonClassificationParser"]

--- a/sv_shared/rewards.py
+++ b/sv_shared/rewards.py
@@ -1,0 +1,55 @@
+"""Shared reward functions for classification environments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .utils import get_response_text
+
+
+def _extract(parser, completion: Any) -> tuple[str, float]:  # noqa: ANN001
+    """Helper to extract parsed label and confidence."""
+
+    text = get_response_text(completion)
+    label = parser.parse_answer(text)
+    confidence = parser.parse_confidence(text)
+    return label, confidence
+
+
+def reward_accuracy(*, completion: Any, answer: str, parser, **kwargs) -> float:  # noqa: ANN001
+    """Binary accuracy reward for classification."""
+
+    predicted, _ = _extract(parser, completion)
+    if not predicted or not answer:
+        return 0.0
+    return 1.0 if predicted.lower() == answer.lower() else 0.0
+
+
+def reward_calibration(*, completion: Any, answer: str, parser, **kwargs) -> float:  # noqa: ANN001
+    """Calibration reward based on absolute error."""
+
+    predicted, conf = _extract(parser, completion)
+    if not predicted:
+        return 0.0
+    correct = 1.0 if predicted.lower() == answer.lower() else 0.0
+    return 1.0 - abs(conf - correct)
+
+
+def reward_asymmetric_cost(*, completion: Any, answer: str, parser, **kwargs) -> float:  # noqa: ANN001
+    """Penalize false negatives more than false positives."""
+
+    predicted, _ = _extract(parser, completion)
+    if not predicted or not answer:
+        return 0.0
+    if predicted.lower() == answer.lower():
+        return 1.0
+    if predicted.lower() == "benign" and answer.lower() == "malicious":
+        return -1.0
+    return 0.0
+
+
+__all__ = [
+    "reward_accuracy",
+    "reward_calibration",
+    "reward_asymmetric_cost",
+]

--- a/sv_shared/utils.py
+++ b/sv_shared/utils.py
@@ -1,0 +1,21 @@
+"""Utility helpers shared across environments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_response_text(completion: Any) -> str:
+    """Extract text content from a completion structure.
+
+    The Verifiers library may return either a raw string or a list of
+    message dictionaries. This helper normalizes those inputs to a plain
+    string for reward functions and parsers.
+    """
+
+    if isinstance(completion, list):
+        return completion[-1].get("content", "") if completion else ""
+    return str(completion)
+
+
+__all__ = ["get_response_text"]


### PR DESCRIPTION
## Summary
- add shared `sv_shared` package with JSON parser and reward helpers
- expand network log environment to JSON outputs with confidence and abstention
- add calibration and cost-sensitive rewards with updated tests and docs
- ensure confidence parser handles `None` values for clean type checking

## Testing
- `ruff check sv_shared environments/sv-env-network-logs/sv_env_network_logs.py environments/sv-env-network-logs/sv_env_network_logs_test.py`
- `pyright sv_shared environments/sv-env-network-logs/sv_env_network_logs.py`
- `pytest environments/sv-env-network-logs -q`


------
https://chatgpt.com/codex/tasks/task_e_68c35abf87588324ac56777be9c5fe6f