### PR TITLE
Refactor config verification environment for shared parsing

### DIFF
--- a/environments/sv-env-config-verification/sv_env_config_verification_test.py
+++ b/environments/sv-env-config-verification/sv_env_config_verification_test.py
@@ -37,6 +37,12 @@ class TestConfigVerificationParser:
         assert parser.parse_answer("Need more information") == "Need more information"
         assert parser.parse_answer("") == ""
 
+    def test_parse_answer_structured_completion(self):
+        """Parser should handle structured completion objects."""
+        parser = ConfigVerificationParser()
+        completion = [{"content": "Compliant"}]
+        assert parser.parse_answer(completion) == "Compliant"
+
     def test_format_reward_perfect(self):
         """Test format reward for perfect responses."""
         parser = ConfigVerificationParser()


### PR DESCRIPTION
## Summary
- reuse `sv_shared.get_response_text` in config verification environment
- ensure tool env uses shared text helper for format, parser, and reward functions

## Testing
- `pytest environments/sv-env-config-verification/sv_env_config_verification_test.py -q`
- `ruff check environments/sv-env-config-verification/sv_env_config_verification.py environments/sv-env-config-verification/sv_env_config_verification_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68c36b5dbebc8324918602821af1fa10