### PR TITLE
Fix end_line parsing in KubeLinter adapter

### DIFF
--- a/e2_config_auditing/adapters/kubelinter_adapter.py
+++ b/e2_config_auditing/adapters/kubelinter_adapter.py
@@ -52,7 +52,7 @@ def kubelinter_lint(
                 message=str(item.get("message", "")),
                 file=item.get("kubeObject", {}).get("file"),
                 start_line=item.get("kubeObject", {}).get("line"),
-                end_line=item.get("kubeObject", {}).get("column"),
+                end_line=item.get("kubeObject", {}).get("endLine"),
                 extra=item,
             )
         )

--- a/e2_config_auditing/tests/kubelinter_adapter_test.py
+++ b/e2_config_auditing/tests/kubelinter_adapter_test.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+from e2_config_auditing.adapters import kubelinter_adapter
+
+
+def test_kubelinter_end_line(monkeypatch: Any) -> None:
+    dummy_output = json.dumps(
+        {
+            "reports": [
+                {
+                    "check": "run-as-non-root",
+                    "severity": "Error",
+                    "message": "msg",
+                    "kubeObject": {
+                        "file": "f.yaml",
+                        "line": 1,
+                        "column": 2,
+                        "endLine": 3,
+                    },
+                }
+            ]
+        }
+    )
+
+    def fake_run(
+        cmd: Any,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+        env: Any,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 0, stdout=dummy_output, stderr="")
+
+    monkeypatch.setattr(kubelinter_adapter.subprocess, "run", fake_run)
+
+    findings = kubelinter_adapter.kubelinter_lint(["f.yaml"])
+    assert findings[0].end_line == 3

--- a/environments/sv-env-config-verification/README.md
+++ b/environments/sv-env-config-verification/README.md
@@ -20,7 +20,7 @@ It exposes Kubernetes and Terraform fixtures with precomputed oracle outputs.
 ## Tools
 
 The environment exposes deterministic wrappers around pinned tools:
-- `kubelinter_lint` – Kubernetes static analysis
+- `kubelinter_lint` – Kubernetes static analysis with file and line range metadata
 - `semgrep_scan` – Terraform / generic pattern scanning
 Tool versions are pinned in `e2_config_auditing/ci/versions.txt` to ensure reproducibility.
 


### PR DESCRIPTION
## Summary
- read `kubeObject.endLine` instead of column for kube-linter findings
- add regression test for end line handling
- document kubelinter_lint's file and line range metadata

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c741b8e7f0832485a644d61d591305