### PR TITLE
Use subprocess check in OPA adapter

### DIFF
--- a/e2_config_auditing/adapters/opa_adapter.py
+++ b/e2_config_auditing/adapters/opa_adapter.py
@@ -37,17 +37,18 @@ def opa_eval(
     for p in policy_paths:
         cmd.extend(["--data", str(p)])
 
-    proc = subprocess.run(
-        cmd,
-        input=input_str,
-        capture_output=True,
-        text=True,
-        timeout=timeout_s,
-        env=env,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise OPAError(proc.stderr.strip() or "opa eval failed")
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=input_str,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            env=env,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise OPAError(exc.stderr.strip() or "opa eval failed") from exc
     try:
         data = json.loads(proc.stdout)
         results = data.get("result", [])


### PR DESCRIPTION
## Summary
- handle `opa eval` failures by enabling `check=True` and catching `CalledProcessError`

## Testing
- `make lint SHELL=/bin/bash`
- `make test SHELL=/bin/bash`


------
https://chatgpt.com/codex/tasks/task_e_68c743c0ead88324991411421528e47c