### PR TITLE
Fix formatting for config verification environment

### DIFF
--- a/environments/sv-env-config-verification/sv_env_config_verification.py
+++ b/environments/sv-env-config-verification/sv_env_config_verification.py
@@ -5,6 +5,7 @@ This package wraps the :mod:`e2_config_auditing` module and exposes it as a
 configuration files, optionally call analysis tools, and must return a JSON
 object with violations, an optional patch, and a confidence score.
 """
+
 from __future__ import annotations
 
 import json
@@ -17,6 +18,7 @@ from datasets import Dataset
 
 # Allow importing shared utilities when developing from the repo
 import sys
+
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 from sv_shared.utils import get_response_text  # type: ignore  # pylint: disable=wrong-import-position
 
@@ -148,9 +150,7 @@ def load_environment(
     )
     return vf.ToolEnv(
         name="sv-env-config-verification",
-        description=(
-            "Audit Kubernetes and Terraform configurations using pinned tool outputs."
-        ),
+        description=("Audit Kubernetes and Terraform configurations using pinned tool outputs."),
         dataset=dataset,
         parser=parser,
         rubric=rubric,

--- a/environments/sv-env-config-verification/sv_env_config_verification_test.py
+++ b/environments/sv-env-config-verification/sv_env_config_verification_test.py
@@ -10,17 +10,13 @@ from sv_env_config_verification import (
 class TestConfigVerification:
     def test_parser_and_format_reward(self) -> None:
         parser = ConfigVerificationParser()
-        completion = (
-            '{"violations":[{"id":"kube-linter/run-as-root","severity":"high"}],"patch":"","confidence":0.9}'
-        )
+        completion = '{"violations":[{"id":"kube-linter/run-as-root","severity":"high"}],"patch":"","confidence":0.9}'
         parsed = parser.parse_answer(completion)
         assert parsed["violations"][0]["id"].startswith("kube-linter/")
         assert parser.get_format_reward_func()(completion) == 1.0
 
     def test_reward_no_patch(self) -> None:
-        completion = (
-            '{"violations":[{"id":"kube-linter/run-as-root","severity":"high"}],"patch":"","confidence":1.0}'
-        )
+        completion = '{"violations":[{"id":"kube-linter/run-as-root","severity":"high"}],"patch":"","confidence":1.0}'
         answer = {
             "oracle": [{"id": "kube-linter/run-as-root", "severity": "high"}],
             "fixture_path": "",


### PR DESCRIPTION
## Summary
- Format `sv_env_config_verification` modules to satisfy `ruff format --check`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c746f92cd08324a83d22dee0e3279c