### PR TITLE
Implement patch-and-test code vulnerability environment

### DIFF
--- a/docs/sv-env-code-vulnerability.md
+++ b/docs/sv-env-code-vulnerability.md
@@ -27,8 +27,8 @@ adding new builders mirroring `_build_sql_injection_example` / `_build_yaml_exam
 
 | Tool | Signature | Description |
 | --- | --- | --- |
-| `run_python_static_scan` | `(code: str) -> dict` | Flags common Python anti-patterns (SQL concatenation, unsafe YAML loader, insecure randomness). |
-| `run_patch_and_tests` | `(original_code: str, diff?: str, patched_code?: str, test_spec?: str) -> PatchTestResult` | Applies the provided diff/patched code and executes the declarative `test_spec`. Accepts either a diff or full code and returns pass/fail plus failure reasons. |
+| `run_python_static_scan` | `(code: str) -> dict` | Flags common Python anti-patterns (AST-backed SQL concatenation detection, unsafe YAML loader, insecure randomness). |
+| `run_patch_and_tests` | `(original_code: str, diff?: str, patched_code?: str, test_spec?: str) -> PatchTestResult` | Applies the provided diff/patched code, validates it against sandbox rules, and executes the declarative `test_spec`. Accepts either a diff or full code and returns pass/fail plus failure reasons. |
 
 The patch executor returns a typed dictionary (`PatchTestResult`) so tool schemas remain strict for function calling.
 
@@ -47,6 +47,12 @@ If the executor fails and reports reasons, a small penalty (-0.1) is applied to 
 
 `CodeVulnerabilityParser` enforces the JSON schema and returns the parsed fields. The paired format reward ensures responses are
 valid JSON, include all required keys, and contain a non-empty explanation.
+
+## Sandbox & Patch Application
+
+- `apply_unified_diff` relies on `unidiff.PatchSet` to parse patches, rejecting malformed or multi-file diffs before any mutation happens.
+- Patched code is validated via AST inspection (import allowlist + disallowed call detection) prior to compilation.
+- Execution uses a read-only builtins mapping with a restricted `__import__`, preventing operations such as `eval`, `open`, or importing arbitrary modules.
 
 ## System Prompt
 

--- a/docs/sv-env-code-vulnerability.md
+++ b/docs/sv-env-code-vulnerability.md
@@ -1,0 +1,72 @@
+# sv-env-code-vulnerability Environment Guide
+
+This document provides reference-level detail for the Vulnerability Repair environment introduced in this change set.
+
+## Purpose
+
+- **Environment name**: `sv-env-code-vulnerability`
+- **Mode**: `vf.ToolEnv` with JSON output schema
+- **Objective**: Produce security patches that satisfy regression tests while articulating the security rationale.
+
+## Dataset Construction
+
+The synthetic dataset is built at load time by `sv_env_code_vulnerability._build_dataset` and currently contains two executable
+tasks. Each entry stores:
+
+- `question`: prompt text with vulnerable source, behavioural requirements, and guidance on the JSON schema.
+- `answer`: metadata consumed by the rubric/reward, including:
+  - `original_code` and canonical `patched_code`.
+  - `expected_diff` computed via `difflib.unified_diff` for reproducible diffs.
+  - `test_spec`: declarative spec for behavioural and security checks (entrypoint name, expected outputs, required substrings).
+  - `explanation_keywords`: keywords required in the textual rationale.
+
+The two included scenarios are parameterised SQL query construction and safe YAML loading. Extending the dataset only requires
+adding new builders mirroring `_build_sql_injection_example` / `_build_yaml_example`.
+
+## Tools
+
+| Tool | Signature | Description |
+| --- | --- | --- |
+| `run_python_static_scan` | `(code: str) -> dict` | Flags common Python anti-patterns (SQL concatenation, unsafe YAML loader, insecure randomness). |
+| `run_patch_and_tests` | `(original_code: str, diff?: str, patched_code?: str, test_spec?: str) -> PatchTestResult` | Applies the provided diff/patched code and executes the declarative `test_spec`. Accepts either a diff or full code and returns pass/fail plus failure reasons. |
+
+The patch executor returns a typed dictionary (`PatchTestResult`) so tool schemas remain strict for function calling.
+
+## Reward
+
+`reward_patch_and_test` combines multiple signals:
+
+1. **Test execution (60%)** – delegates to `run_patch_and_tests` and scores 1.0 when regression tests pass.
+2. **Diff similarity (20%)** – `difflib.SequenceMatcher` between submitted diff and canonical diff.
+3. **Consistency (10%)** – compares claimed `tests_passed` to executor outcome.
+4. **Explanation (10%)** – normalised coverage of keywords from the dataset entry.
+
+If the executor fails and reports reasons, a small penalty (-0.1) is applied to guard against overly optimistic answers.
+
+## Parser & Format Reward
+
+`CodeVulnerabilityParser` enforces the JSON schema and returns the parsed fields. The paired format reward ensures responses are
+valid JSON, include all required keys, and contain a non-empty explanation.
+
+## System Prompt
+
+```
+You are a secure code maintainer. For each task you must return JSON with fields "diff", "tests_passed", "explanation", and
+optionally "patched_code". Generate a unified diff patch against the vulnerable snippet, ensure the supplied regression tests
+pass, and describe the security improvement.
+```
+
+This prompt is surfaced automatically via `load_environment`.
+
+## Testing
+
+The new unit tests (`sv_env_code_vulnerability_test.py`) exercise:
+
+- Parser parsing and format reward.
+- Static scan heuristics.
+- Unified diff application.
+- Patch execution success/failure.
+- Reward shaping for correct, incorrect, and regressive patches.
+- Environment loader wiring (dataset length, tool schemas, rubric).
+
+Run `uv run pytest environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py` to validate locally.

--- a/environments/sv-env-code-vulnerability/README.md
+++ b/environments/sv-env-code-vulnerability/README.md
@@ -1,98 +1,107 @@
-# Vulnerability Repair in Code (Work in Progress)
+# Vulnerability Repair in Code
 
-Security Verifiers RL environment for **Vulnerability Repair with Patch-and-Test Loops** - implementing Environment E3 from the [PRD](../../PRD.md).
+Security Verifiers environment for **patch-and-test vulnerability remediation** (Environment E3 in the
+[PRD](../../PRD.md)). The environment now executes a full loop: generate a unified diff, apply the patch to
+the vulnerable snippet, run security-focused regression tests, and score the result.
 
 ## Overview
 
-This environment (currently in development) will implement executable vulnerability repair where models fix vulnerable code while maintaining functionality. Rewards are based on tests passing, static security improvements, and patch minimality - all verifiable through execution.
+- **Task**: Given a vulnerable Python helper, return a JSON object describing the patch, test outcome, and security rationale.
+- **Schema**:
 
-## Planned Features (Per PRD Specification)
+  ```json
+  {
+    "diff": "unified diff string",
+    "tests_passed": true,
+    "explanation": "short natural-language summary",
+    "patched_code": "optional full code listing"
+  }
+  ```
 
-### Input/Output Schema
+- **Tools**:
+  - `run_python_static_scan`: heuristic SAST signal for risky constructs (SQL concatenation, unsafe YAML loading, insecure randomness).
+  - `run_patch_and_tests`: apply a diff or patched code, execute behavior + security checks, and report pass/fail.
 
-- **Input**: Vulnerable code snippet + failing unit/security tests
-- **Output Schema**:
+- **Reward** (`reward_patch_and_test`):
+  - 60% from executing the regression suite (must pass).
+  - 20% from similarity between submitted diff and reference patch.
+  - 10% from consistency between claimed `tests_passed` and executor result.
+  - 10% from covering reference explanation keywords.
+
+## Dataset
+
+The first working release ships a curated synthetic dataset with executable examples:
+
+| ID | Vulnerability | Required Fix | Regression Focus |
+| --- | --- | --- | --- |
+| `sql_injection_parameterization` | f-string SQL concatenation | Return `(query, params)` tuple using placeholders | Parameterised queries and placeholder presence |
+| `yaml_safe_load` | `yaml.load` with `FullLoader` | Switch to `yaml.safe_load` while preserving benign parsing | Benign config parse + malicious payload rejection |
+
+Each example stores the vulnerable source, canonical patch, and a machine-executable `test_spec`. The environment loads
+these as a `datasets.Dataset`, so evaluation is deterministic and tool-friendly.
+
+### Example Prompt
+
+````text
+You are securing a Python helper that builds SQL queries. Patch the vulnerability and return JSON with fields
+"diff", "tests_passed", "explanation", and optional "patched_code".
+
+Vulnerable implementation:
+```python
+def build_query(username: str) -> str:
+    """Return a SQL query for the supplied username."""
+
+    return f"SELECT * FROM users WHERE name = '{username}'"
+```
+
+Requirements:
+- Return a parameterized query string alongside a tuple of parameters.
+- Ensure suspicious usernames do not appear directly embedded in the SQL string.
+- Keep the function signature unchanged.
+````
+
+### Example Output
 
 ```json
 {
-  "diff": "unified diff",
-  "tests_passed": true|false,
-  "explanation": "string"
+  "diff": "--- query.py\n+++ query.py\n@@ -1,4 +1,6 @@\n-def build_query(username: str) -> str:\n-    \"\"\"Return a SQL query for the supplied username.\"\"\"\n-\n-    return f\"SELECT * FROM users WHERE name = '{username}'\"\n+def build_query(username: str) -> tuple[str, tuple[str, ...]]:\n+    \"\"\"Return a parameterized SQL query and parameters.\"\"\"\n+\n+    query = \"SELECT * FROM users WHERE name = ?\"\n+    params = (username,)\n+    return query, params\n",
+  "tests_passed": true,
+  "explanation": "The query is parameterized and no longer concatenates user input.",
+  "patched_code": "def build_query(..." 
 }
 ```
 
-### Reward Structure
+## Implementation Notes
 
-- Primary: Tests must pass (functionality preserved)
-- Security delta: Bandit/Semgrep warnings must decrease
-- Minimality bonus: Smaller diffs preferred
-- No coverage drop: Patches shouldn't reduce test coverage
+- **Parser**: `CodeVulnerabilityParser` enforces JSON schema compliance and exposes a format reward for tidy answers.
+- **Patch Executor**: `apply_unified_diff` is a lightweight single-file patcher used by both the reward function and tool.
+- **Testing Harness**: `run_patch_and_tests` executes deterministic behavioural & security checks from `test_spec`
+  (e.g. parameter tuple equality, exception expectations for malicious payloads, token placeholder enforcement).
+- **Environment**: `load_environment` builds a `vf.ToolEnv` with the dataset, tools, parser, rubric, and system prompt.
 
-### Datasets
+## Running Tests
 
-- Devign: Function-level vulnerability detection
-- Big-Vul: Real-world vulnerability patches
-- Juliet Test Suite: Controlled CWE examples
-- CodeXGLUE: Defect detection benchmark
-
-## Key Innovations
-
-1. **Executable Verification**: Not just detecting vulnerabilities but producing patches that actually work (tests pass)
-
-2. **Multi-Objective Optimization**: Balance security fixes with functionality preservation and code minimality
-
-3. **Iterative Refinement**: Multi-turn environment allows model to refine patches based on test results
-
-4. **Real-World Relevance**: Training on actual CVE patches from Big-Vul dataset
-
-## Current Status
-
-This environment is a work in progress. The current implementation provides basic vulnerability detection as a foundation. Future development will add:
-
-- Full test execution harness with sandboxing
-- Integration with Bandit and Semgrep for security scoring
-- Diff generation and validation
-- Coverage tracking to ensure quality patches
-- Curriculum learning from simple to complex vulnerabilities
-
-See [PRD.md](../../PRD.md) Environment E3 for full specifications.
-
-## Example Workflow (Target Implementation)
-
-```text
-Input: Buffer overflow in C function + unit tests
-Turn 1: Model analyzes code, identifies unsafe gets()
-Turn 2: Model generates patch using fgets() with bounds checking
-Turn 3: Tests execute → pass ✓
-Turn 4: Bandit scan → warnings reduced ✓
-Output: {"diff": "...", "tests_passed": true,
-         "explanation": "Replaced gets() with fgets() to prevent buffer overflow"}
-Reward: 1.0 (tests pass) + 0.5 (security improved) + 0.25 (minimal diff)
+```bash
+uv run pytest environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py
 ```
 
-## Structure
+This exercises parser behaviour, static scan heuristics, diff application, the patch-and-test loop, reward shaping, and loader wiring.
 
-- `sv_env_code_vulnerability.py`: Main implementation file
-- `sv_env_code_vulnerability_test.py`: Test suite
+## Installation
 
-## Safety Considerations
-
-- Sandboxed test execution to prevent malicious code
-- Resource limits (CPU, memory, time) for all executions
-- No network access during code evaluation
-- Careful handling of dataset vulnerabilities (never execute without patches)
-
-## Local Install (editable)
-
-From repo root after creating a uv venv:
+Install in editable mode from the repository root:
 
 ```bash
 uv pip install -e environments/sv-env-code-vulnerability
 ```
 
-## Related Work
+## Safety
 
-This environment is part of the Open Security Verifiers suite. For the complete vision, see:
+- Only trusted, synthetic snippets are executed.
+- The executor runs in-process but only evaluates curated tests; no network or filesystem writes are required.
+- Expansion to external datasets should keep this safety profile (sandboxing, timeouts) before execution is enabled.
 
-- [EXECUTIVE_SUMMARY.md](../../EXECUTIVE_SUMMARY.md) - Project overview
-- [PRD.md](../../PRD.md) - Detailed specifications for all six environments
+## Related Docs
+
+- [EXECUTIVE_SUMMARY.md](../../EXECUTIVE_SUMMARY.md) – project overview.
+- [PRD.md](../../PRD.md) – specification for all Security Verifiers environments.

--- a/environments/sv-env-code-vulnerability/README.md
+++ b/environments/sv-env-code-vulnerability/README.md
@@ -19,8 +19,8 @@ the vulnerable snippet, run security-focused regression tests, and score the res
   ```
 
 - **Tools**:
-  - `run_python_static_scan`: heuristic SAST signal for risky constructs (SQL concatenation, unsafe YAML loading, insecure randomness).
-  - `run_patch_and_tests`: apply a diff or patched code, execute behavior + security checks, and report pass/fail.
+  - `run_python_static_scan`: heuristic SAST signal for risky constructs (AST-backed SQL concatenation detection, unsafe YAML loading, insecure randomness).
+  - `run_patch_and_tests`: apply a diff or patched code, execute behavior + security checks inside a sandboxed runtime, and report pass/fail.
 
 - **Reward** (`reward_patch_and_test`):
   - 60% from executing the regression suite (must pass).
@@ -74,9 +74,10 @@ Requirements:
 ## Implementation Notes
 
 - **Parser**: `CodeVulnerabilityParser` enforces JSON schema compliance and exposes a format reward for tidy answers.
-- **Patch Executor**: `apply_unified_diff` is a lightweight single-file patcher used by both the reward function and tool.
+- **Patch Executor**: `apply_unified_diff` relies on `unidiff.PatchSet` to parse unified diffs before patching, rejecting malformed or multi-file patches early.
 - **Testing Harness**: `run_patch_and_tests` executes deterministic behavioural & security checks from `test_spec`
   (e.g. parameter tuple equality, exception expectations for malicious payloads, token placeholder enforcement).
+- **Sandbox**: Patched code is validated with the Python AST, allowed imports are whitelisted, and execution runs with a read-only builtins mapping to constrain effects.
 - **Environment**: `load_environment` builds a `vf.ToolEnv` with the dataset, tools, parser, rubric, and system prompt.
 
 ## Running Tests
@@ -98,7 +99,7 @@ uv pip install -e environments/sv-env-code-vulnerability
 ## Safety
 
 - Only trusted, synthetic snippets are executed.
-- The executor runs in-process but only evaluates curated tests; no network or filesystem writes are required.
+- The executor validates patched code (AST inspection + import allowlist) and runs with restricted builtins, preventing `eval`, `open`, and other dangerous primitives.
 - Expansion to external datasets should keep this safety profile (sandboxing, timeouts) before execution is enabled.
 
 ## Related Docs

--- a/environments/sv-env-code-vulnerability/pyproject.toml
+++ b/environments/sv-env-code-vulnerability/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "tree-sitter-python>=0.20.0",
   "tree-sitter-c>=0.20.0",
   "semgrep>=1.45.0",
+  "unidiff>=0.7.5",
 ]
 
 [project.entry-points."verifiers.environments"]

--- a/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
+++ b/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
@@ -1,437 +1,610 @@
-"""sv_env_code_vulnerability: Security Verifiers environment for Code Vulnerability Assessment.
-
-This package implements PRD Environment #5: A ToolEnv/MultiTurnEnv where models inspect
-source code for security vulnerabilities and suggest fixes. The model can call static
-analysis functions and propose corrected code snippets.
-"""
+"""Security Verifiers environment: code vulnerability repair with patch-and-test."""
 
 from __future__ import annotations
 
-from typing import Any, Dict
-
+import json
+import textwrap
+from dataclasses import dataclass
+from difflib import SequenceMatcher, unified_diff
 from pathlib import Path
 import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
+from typing import Any, Dict, Iterable, List, Optional
+from typing_extensions import TypedDict
 
 import verifiers as vf
 from datasets import Dataset
 
-from sv_shared import RolloutLogger  # type: ignore  # pylint: disable=wrong-import-position
+# Allow importing shared utilities when running from the repo root.
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from sv_shared import RolloutLogger, get_response_text  # type: ignore  # pylint: disable=wrong-import-position
+
+
+def apply_unified_diff(original: str, diff: str) -> Optional[str]:
+    """Apply a unified diff string to the original code."""
+
+    if not diff.strip():
+        return original
+
+    original_lines = original.splitlines()
+    diff_lines = diff.splitlines()
+    patched_lines: List[str] = []
+    original_index = 0
+
+    def flush_until(target_index: int) -> None:
+        nonlocal original_index
+        while original_index < min(target_index, len(original_lines)):
+            patched_lines.append(original_lines[original_index])
+            original_index += 1
+
+    for line in diff_lines:
+        if line.startswith("---") or line.startswith("+++"):
+            continue
+        if line.startswith("@@"):
+            try:
+                _, old_range, _ = line.split(" ")[:3]
+                old_start = int(old_range.split(",")[0][1:]) - 1
+            except (ValueError, IndexError):
+                return None
+            flush_until(old_start)
+            continue
+        if line.startswith("-"):
+            original_index += 1
+            continue
+        if line.startswith("+"):
+            patched_lines.append(line[1:])
+            continue
+        if line.startswith(" "):
+            if original_index >= len(original_lines):
+                return None
+            patched_lines.append(original_lines[original_index])
+            original_index += 1
+    flush_until(len(original_lines))
+
+    return "\n".join(patched_lines)
+
+
+def _normalize_query_result(result: Any) -> Any:
+    """Normalize SQL query return values to comparable dictionaries."""
+
+    if isinstance(result, dict) and "query" in result:
+        params = result.get("params", ())
+        if isinstance(params, list):
+            params = tuple(params)
+        elif not isinstance(params, tuple):
+            params = (params,)
+        return {"query": result["query"], "params": tuple(params)}
+
+    if isinstance(result, tuple) and len(result) == 2:
+        query, params = result
+        if isinstance(params, list):
+            params = tuple(params)
+        elif not isinstance(params, tuple):
+            params = (params,)
+        return {"query": query, "params": tuple(params)}
+
+    return result
+
+
+def _execute_behavioral_test(func: Any, case: Dict[str, Any], category: str, failures: List[str]) -> None:
+    args = case.get("args", [])
+    kwargs = case.get("kwargs", {})
+
+    expected = case.get("expected")
+    expects_exception = case.get("raises", False)
+
+    if expects_exception:
+        try:
+            func(*args, **kwargs)
+        except Exception:  # noqa: broad-except - used for sandboxed tests
+            return
+        failures.append(
+            f"{category}: expected an exception for input {args} but none was raised."
+        )
+        return
+
+    try:
+        result = func(*args, **kwargs)
+    except Exception as exc:  # noqa: broad-except - bubble up failure context
+        failures.append(
+            f"{category}: call with {args} raised {exc.__class__.__name__}: {exc}"
+        )
+        return
+
+    if expected is not None:
+        normalized_expected = _normalize_query_result(expected)
+        normalized_result = _normalize_query_result(result)
+        if normalized_expected != normalized_result:
+            failures.append(
+                f"{category}: expected {normalized_expected} but received {normalized_result}"
+            )
+
+
+def _check_code_properties(patched_code: str, spec: Dict[str, Any], failures: List[str]) -> None:
+    for substring in spec.get("required_substrings_in_code", []):
+        if substring not in patched_code:
+            if substring == "?":
+                failures.append(
+                    "Patched code missing required '?' placeholder for parameterized queries."
+                )
+            else:
+                failures.append(f"Patched code missing required token '{substring}'.")
+
+    for substring in spec.get("forbidden_substrings_in_code", []):
+        if substring in patched_code:
+            failures.append(f"Patched code still contains forbidden token '{substring}'.")
+
+
+class PatchTestResult(TypedDict):
+    """Structured output for the patch-and-test tool."""
+
+    patched_code: str
+    tests_passed: bool
+    failures: List[str]
+    details: List[str]
+
+
+def run_patch_and_tests(
+    *,
+    original_code: str,
+    diff: str | None = None,
+    patched_code: str | None = None,
+    test_spec: str | None = None,
+) -> PatchTestResult:
+    """Apply a candidate patch and execute the behavioral/security tests."""
+
+    spec_dict: Dict[str, Any] | None
+
+    if isinstance(test_spec, dict):
+        spec_dict = test_spec
+    elif isinstance(test_spec, str) and test_spec.strip():
+        try:
+            spec_dict = json.loads(test_spec)
+        except json.JSONDecodeError:
+            spec_dict = None
+    else:
+        spec_dict = None
+
+    if patched_code is None:
+        patched_code = apply_unified_diff(original_code, diff or "")
+
+    if patched_code is None:
+        return {
+            "patched_code": original_code,
+            "tests_passed": False,
+            "failures": ["Failed to apply diff to original code."],
+            "details": [],
+        }
+
+    if not spec_dict:
+        return {
+            "patched_code": patched_code,
+            "tests_passed": False,
+            "failures": ["No test specification provided."],
+            "details": [],
+        }
+
+    namespace: Dict[str, Any] = {}
+    exec(patched_code, namespace)  # noqa: S102 - deliberate execution of trusted dataset code
+
+    entrypoint = spec_dict.get("entrypoint")
+    func = namespace.get(entrypoint)
+
+    if not callable(func):
+        return {
+            "patched_code": patched_code,
+            "tests_passed": False,
+            "failures": [f"Entrypoint '{entrypoint}' is not callable in patched code."],
+            "details": [],
+        }
+
+    failures: List[str] = []
+
+    for case in spec_dict.get("behavioral_tests", []):
+        _execute_behavioral_test(func, case, "Behavioral", failures)
+
+    for case in spec_dict.get("security_tests", []):
+        _execute_behavioral_test(func, case, "Security", failures)
+
+    _check_code_properties(patched_code, spec_dict, failures)
+
+    return {
+        "patched_code": patched_code,
+        "tests_passed": not failures,
+        "failures": failures,
+        "details": [],
+    }
+
+
+def run_python_static_scan(code: str) -> Dict[str, Any]:
+    """Simple heuristic static analysis for Python snippets."""
+
+    code_lower = code.lower()
+    vulnerabilities: List[str] = []
+
+    if "select" in code_lower and (
+        "%" in code
+        or ".format" in code_lower
+        or "{" in code and "}" in code
+        or "+" in code_lower
+    ):
+        vulnerabilities.append(
+            "SQL injection risk: query string uses concatenation/formatting without parameters."
+        )
+
+    if "yaml.load" in code_lower and "safe_load" not in code_lower:
+        vulnerabilities.append(
+            "Unsafe YAML loading: yaml.load without SafeLoader exposes arbitrary object execution."
+        )
+
+    if "random" in code_lower and "token" in code_lower and "secrets" not in code_lower:
+        vulnerabilities.append(
+            "Insecure randomness: prefer secrets.token_hex for security tokens."
+        )
+
+    return {
+        "language": "python",
+        "vulnerabilities_found": len(vulnerabilities),
+        "vulnerabilities": vulnerabilities,
+        "verdict": "Vulnerable" if vulnerabilities else "Secure",
+    }
 
 
 class CodeVulnerabilityParser(vf.Parser):
-    """Parser to extract vulnerability findings and fixes from model responses."""
+    """Parser for JSON-structured vulnerability repair outputs."""
 
-    def parse_answer(self, completion: str) -> str:
-        """Extract vulnerability detection and fix from the response.
+    def parse_answer(self, completion: Any) -> Dict[str, Any]:
+        text = get_response_text(completion)
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return {}
 
-        Args:
-            completion: The raw model completion/response.
-
-        Returns:
-            The extracted vulnerability assessment.
-        """
-        # Clean and normalize the response
-        cleaned = completion.strip().lower()
-
-        # Look for vulnerability indicators
-        # Check "fixed" before "vulnerability"
-        if "fixed" in cleaned or "has been fixed" in cleaned:
-            return "Fixed"
-        if "vulnerable" in cleaned or "vulnerability" in cleaned:
-            return "Vulnerable"
-        if "secure" in cleaned and "insecure" not in cleaned:
-            return "Secure"
-
-        # Return original if no clear assessment found
-        return completion.strip()
+        return {
+            "diff": str(data.get("diff", "")),
+            "tests_passed": bool(data.get("tests_passed", False)),
+            "explanation": str(data.get("explanation", "")),
+            "patched_code": str(data.get("patched_code", "")),
+        }
 
     def get_format_reward_func(self):
-        """Return a format reward function that checks for proper vulnerability report format."""
+        required_keys = {"diff", "tests_passed", "explanation"}
 
-        def format_reward(
-            completion,
-            answer="",  # pylint: disable=unused-argument
-            **kwargs,  # pylint: disable=unused-argument
-        ):
-            """Reward proper vulnerability analysis format."""
-            # Extract response text from completion
-            if isinstance(completion, list):
-                response = completion[-1]["content"] if completion else ""
-            else:
-                response = str(completion)
+        def format_reward(completion, answer="", **_kwargs):  # pylint: disable=unused-argument
+            text = get_response_text(completion)
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                return 0.0
 
-            cleaned = response.strip().lower()
+            if not required_keys.issubset(data):
+                return 0.0
 
-            # Perfect format: identifies vulnerability and provides fix
-            if any(v in cleaned for v in ["vulnerable", "vulnerability", "issue", "problem"]) and any(  # pylint: disable=line-too-long
-                f in cleaned for f in ["fix", "corrected", "secure version", "should be"]
-            ):
-                return 1.0
-
-            # Good format: identifies issue but no fix
-            if any(v in cleaned for v in ["vulnerable", "vulnerability", "secure", "issue"]):
+            if not isinstance(data.get("tests_passed"), bool):
                 return 0.5
 
-            # Poor format: no clear analysis
-            return 0.0
+            explanation = str(data.get("explanation", ""))
+            return 1.0 if explanation.strip() else 0.5
 
         return format_reward
 
 
-def scan_python_code(code: str) -> Dict[str, Any]:
-    """Tool function to scan Python code for common vulnerabilities.
-
-    Args:
-        code: Python source code to analyze.
-
-    Returns:
-        Dictionary containing scan results and detected vulnerabilities.
-    """
-    vulnerabilities = []
-    severity_scores = []
-
-    code_lower = code.lower()
-
-    # Check for common Python vulnerabilities
-    if "eval(" in code:
-        vulnerabilities.append("Use of eval() - code injection risk")
-        severity_scores.append(9)
-
-    if "exec(" in code:
-        vulnerabilities.append("Use of exec() - code execution vulnerability")
-        severity_scores.append(9)
-
-    if "pickle.loads" in code:
-        vulnerabilities.append("Unsafe pickle deserialization - remote code execution")
-        severity_scores.append(8)
-
-    if "os.system" in code or "subprocess.call" in code:
-        if "shell=true" in code_lower.replace(" ", ""):
-            vulnerabilities.append("Command injection via shell=True")
-            severity_scores.append(9)
-
-    if "sql" in code_lower and ("%s" in code or "format(" in code or "+" in code):
-        vulnerabilities.append("Potential SQL injection - use parameterized queries")
-        severity_scores.append(8)
-
-    if "random.random" in code and ("password" in code_lower or "token" in code_lower):
-        vulnerabilities.append("Weak random number generation for security tokens")
-        severity_scores.append(6)
-
-    if "md5" in code_lower or "sha1" in code_lower:
-        vulnerabilities.append("Use of weak cryptographic hash function")
-        severity_scores.append(5)
-
-    max_severity = max(severity_scores) if severity_scores else 0
-
-    return {
-        "language": "Python",
-        "vulnerabilities_found": len(vulnerabilities),
-        "vulnerabilities": vulnerabilities,
-        "max_severity": max_severity,
-        "verdict": "Vulnerable" if vulnerabilities else "Secure",
-    }
-
-
-def scan_c_code(code: str) -> Dict[str, Any]:
-    """Tool function to scan C/C++ code for common vulnerabilities.
-
-    Args:
-        code: C/C++ source code to analyze.
-
-    Returns:
-        Dictionary containing scan results and detected vulnerabilities.
-    """
-    vulnerabilities = []
-    severity_scores = []
-
-    # Check for common C/C++ vulnerabilities
-    if "gets(" in code:
-        vulnerabilities.append("Use of gets() - buffer overflow vulnerability")
-        severity_scores.append(10)
-
-    if "strcpy(" in code:
-        vulnerabilities.append("Use of strcpy() - potential buffer overflow")
-        severity_scores.append(8)
-
-    if "strcat(" in code:
-        vulnerabilities.append("Use of strcat() - potential buffer overflow")
-        severity_scores.append(8)
-
-    if "sprintf(" in code:
-        vulnerabilities.append("Use of sprintf() - format string vulnerability")
-        severity_scores.append(7)
-
-    if 'scanf("%s' in code:
-        vulnerabilities.append("Unsafe scanf() usage - buffer overflow risk")
-        severity_scores.append(8)
-
-    if "system(" in code:
-        vulnerabilities.append("Use of system() - command injection risk")
-        severity_scores.append(9)
-
-    if "rand()" in code and "seed" not in code.lower():
-        vulnerabilities.append("Weak random number generation")
-        severity_scores.append(5)
-
-    max_severity = max(severity_scores) if severity_scores else 0
-
-    return {
-        "language": "C/C++",
-        "vulnerabilities_found": len(vulnerabilities),
-        "vulnerabilities": vulnerabilities,
-        "max_severity": max_severity,
-        "verdict": "Vulnerable" if vulnerabilities else "Secure",
-    }
-
-
-def reward_vulnerability_detection(
+def reward_patch_and_test(
     completion,
-    answer: str = "",
-    tools_used: list | None = None,
-    **kwargs,  # pylint: disable=unused-argument
+    answer: Dict[str, Any] | None = None,
+    tools_used: Iterable[str] | None = None,  # noqa: ARG001 - part of ToolEnv interface
+    **_kwargs,
 ) -> float:
-    """Reward function for successful vulnerability detection and fixing.
+    """Reward function combining tests, diff similarity, and explanation quality."""
 
-    Args:
-        completion: The model's response with vulnerability analysis.
-        answer: The ground truth vulnerabilities from the dataset.
-        tools_used: List of analysis tools used.
-        **kwargs: Additional arguments.
-
-    Returns:
-        Reward based on detection accuracy and fix quality.
-    """
-    # Extract the response text from completion
-    if isinstance(completion, list):
-        response = completion[-1]["content"] if completion else ""
-    else:
-        response = str(completion)
-
-    response_lower = response.lower()
-
-    # Bonus for using analysis tools
-    tool_bonus = 0.2 if tools_used else 0.0
+    del tools_used
 
     if not answer:
-        return 0.0 + tool_bonus
+        return 0.0
 
-    answer_lower = answer.lower()
+    text = get_response_text(completion)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return 0.0
 
-    # Check if vulnerabilities were correctly identified
-    detection_score = 0.0
-    if "vulnerable" in answer_lower:
-        if "vulnerable" in response_lower or "vulnerability" in response_lower:
-            detection_score = 0.5
-    elif "secure" in answer_lower:
-        if "secure" in response_lower and "vulnerable" not in response_lower:
-            detection_score = 0.5
+    diff = str(data.get("diff", ""))
+    claimed_tests_passed = bool(data.get("tests_passed", False))
+    explanation = str(data.get("explanation", ""))
+    patched_code = data.get("patched_code")
 
-    # Check if fix was provided when needed
-    fix_score = 0.0
-    if "vulnerable" in answer_lower:
-        if any(word in response_lower for word in ["fix", "should use", "instead", "corrected"]):
-            fix_score = 0.5
+    original_code = answer.get("original_code", "")
+    expected_diff = answer.get("expected_diff", "")
+    test_spec = answer.get("test_spec", {})
+    keywords = answer.get("explanation_keywords", [])
 
-    return min(1.0, detection_score + fix_score + tool_bonus)
+    if isinstance(patched_code, str) and patched_code.strip():
+        candidate_code = patched_code
+        patch_result = run_patch_and_tests(
+            original_code=original_code,
+            patched_code=candidate_code,
+            test_spec=json.dumps(test_spec),
+        )
+    else:
+        patch_result = run_patch_and_tests(
+            original_code=original_code,
+            diff=diff,
+            test_spec=json.dumps(test_spec),
+        )
+        candidate_code = patch_result.get("patched_code", "")
+
+    actual_tests_passed = bool(patch_result.get("tests_passed", False))
+
+    tests_score = 1.0 if actual_tests_passed else 0.0
+    consistency_score = 1.0 if actual_tests_passed == claimed_tests_passed else 0.0
+
+    if expected_diff and diff:
+        diff_similarity = SequenceMatcher(None, expected_diff.strip(), diff.strip()).ratio()
+    elif expected_diff:
+        diff_similarity = 0.0
+    else:
+        diff_similarity = 1.0
+
+    if keywords:
+        explanation_lower = explanation.lower()
+        matches = sum(1 for kw in keywords if kw.lower() in explanation_lower)
+        explanation_score = matches / len(keywords)
+    else:
+        explanation_score = 1.0 if explanation.strip() else 0.0
+
+    base_reward = (
+        0.6 * tests_score
+        + 0.2 * diff_similarity
+        + 0.1 * consistency_score
+        + 0.1 * explanation_score
+    )
+
+    if not actual_tests_passed and patch_result.get("failures"):
+        base_reward = max(0.0, base_reward - 0.1)
+
+    return min(base_reward, 1.0)
+
+
+@dataclass
+class DatasetExample:
+    """Simple container for dataset entries."""
+
+    question: str
+    answer: Dict[str, Any]
+
+
+def _build_sql_injection_example() -> DatasetExample:
+    vulnerable_code = textwrap.dedent(
+        '''
+        def build_query(username: str) -> str:
+            """Return a SQL query for the supplied username."""
+
+            return f"SELECT * FROM users WHERE name = '{username}'"
+        '''
+    ).strip()
+
+    patched_code = textwrap.dedent(
+        '''
+        def build_query(username: str) -> tuple[str, tuple[str, ...]]:
+            """Return a parameterized SQL query and parameters."""
+
+            query = "SELECT * FROM users WHERE name = ?"
+            params = (username,)
+            return query, params
+        '''
+    ).strip()
+
+    diff = "\n".join(
+        unified_diff(
+            vulnerable_code.splitlines(),
+            patched_code.splitlines(),
+            fromfile="query.py",
+            tofile="query.py",
+            lineterm="",
+        )
+    )
+
+    question = textwrap.dedent(
+        f"""
+        You are securing a Python helper that builds SQL queries. Patch the vulnerability and
+        return JSON with fields "diff", "tests_passed", "explanation", and optional "patched_code".
+
+        Vulnerable implementation:
+        ```python
+        {vulnerable_code}
+        ```
+
+        Requirements:
+        - Return a parameterized query string alongside a tuple of parameters.
+        - Ensure suspicious usernames do not appear directly embedded in the SQL string.
+        - Keep the function signature unchanged.
+        """
+    ).strip()
+
+    answer = {
+        "id": "sql_injection_parameterization",
+        "language": "python",
+        "original_code": vulnerable_code,
+        "patched_code": patched_code,
+        "expected_diff": diff,
+        "test_spec": {
+            "entrypoint": "build_query",
+            "behavioral_tests": [
+                {
+                    "args": ["alice"],
+                    "expected": {
+                        "query": "SELECT * FROM users WHERE name = ?",
+                        "params": ("alice",),
+                    },
+                }
+            ],
+            "security_tests": [
+                {
+                    "args": ["bob' OR '1'='1"],
+                    "expected": {
+                        "query": "SELECT * FROM users WHERE name = ?",
+                        "params": ("bob' OR '1'='1",),
+                    },
+                }
+            ],
+            "required_substrings_in_code": ["?"],
+            "forbidden_substrings_in_code": ["%", "+"],
+        },
+        "expected_tests_passed": True,
+        "explanation_keywords": ["parameterized", "parameters"],
+    }
+
+    return DatasetExample(question=question, answer=answer)
+
+
+def _build_yaml_example() -> DatasetExample:
+    vulnerable_code = textwrap.dedent(
+        '''
+        import yaml
+
+
+        def load_config(document: str):
+            """Load YAML configuration without safety checks."""
+
+            return yaml.load(document, Loader=yaml.FullLoader)
+        '''
+    ).strip()
+
+    patched_code = textwrap.dedent(
+        '''
+        import yaml
+
+
+        def load_config(document: str):
+            """Safely load YAML configuration using safe_load."""
+
+            return yaml.safe_load(document)
+        '''
+    ).strip()
+
+    diff = "\n".join(
+        unified_diff(
+            vulnerable_code.splitlines(),
+            patched_code.splitlines(),
+            fromfile="config.py",
+            tofile="config.py",
+            lineterm="",
+        )
+    )
+
+    question = textwrap.dedent(
+        f"""
+        Harden the YAML loader below. Replace the unsafe behaviour and report the diff along with
+        whether the provided regression tests pass.
+
+        ```python
+        {vulnerable_code}
+        ```
+
+        Security expectations:
+        - Use a safe loader that prevents arbitrary object construction.
+        - Benign configuration strings should still parse into Python dictionaries.
+        - Malicious payloads such as ``!!python/object/apply`` must raise an exception.
+        """
+    ).strip()
+
+    answer = {
+        "id": "yaml_safe_load",
+        "language": "python",
+        "original_code": vulnerable_code,
+        "patched_code": patched_code,
+        "expected_diff": diff,
+        "test_spec": {
+            "entrypoint": "load_config",
+            "behavioral_tests": [
+                {
+                    "args": ["debug: false"],
+                    "expected": {"debug": False},
+                }
+            ],
+            "security_tests": [
+                {
+                    "args": ["!!python/object/apply:os.system ['echo unsafe']"],
+                    "raises": True,
+                }
+            ],
+            "required_substrings_in_code": ["safe_load"],
+            "forbidden_substrings_in_code": ["yaml.load"],
+        },
+        "expected_tests_passed": True,
+        "explanation_keywords": ["safe_load", "unsafe", "yaml"],
+    }
+
+    return DatasetExample(question=question, answer=answer)
+
+
+def _build_dataset(max_examples: int | None = None) -> Dataset:
+    examples = [_build_sql_injection_example(), _build_yaml_example()]
+
+    if max_examples is not None:
+        examples = examples[:max_examples]
+
+    dataset_dicts = [
+        {"question": example.question, "answer": example.answer}
+        for example in examples
+    ]
+
+    return Dataset.from_list(dataset_dicts)
 
 
 def load_environment(
-    dataset_name: str = "synthetic",  # pylint: disable=unused-argument
-    max_examples: int = 100,
+    dataset_name: str | None = None,
+    max_examples: int | None = None,
     logger: RolloutLogger | None = None,
 ) -> vf.ToolEnv:
-    """Load the Code Vulnerability Assessment environment.
+    """Load the vulnerability repair environment as a ToolEnv."""
 
-    This environment is a tool-enabled task where the model inspects source code
-    for security vulnerabilities and suggests fixes.
+    del dataset_name
 
-    Args:
-        dataset_name: Dataset name (currently only synthetic supported).
-        max_examples: Maximum number of examples to use.
-        logger: Optional rollout logger capturing dataset metadata.
-
-    Returns:
-        A Verifiers ToolEnv configured for the task.
-    """
-
-    def _create_synthetic_dataset():
-        """Create a synthetic dataset of vulnerable code snippets."""
-        examples = []
-
-        # pylint: disable=line-too-long
-        code_examples = [
-            # Python vulnerabilities
-            {
-                "question": (
-                    "Analyze this Python code for vulnerabilities:\n"
-                    "```python\n"
-                    "def process_input(user_input):\n"
-                    "    result = eval(user_input)\n"
-                    "    return result\n"
-                    "```"
-                ),
-                "answer": "Vulnerable: eval() allows arbitrary code execution",
-                "language": "python",
-            },
-            {
-                "question": (
-                    "Review this Python code:\n"
-                    "```python\n"
-                    "import subprocess\n"
-                    "def run_command(cmd):\n"
-                    "    subprocess.call(cmd, shell=True)\n"
-                    "```"
-                ),
-                "answer": "Vulnerable: shell=True enables command injection",
-                "language": "python",
-            },
-            {
-                "question": (
-                    "Check this Python code:\n"
-                    "```python\n"
-                    "import hashlib\n"
-                    "def hash_password(password):\n"
-                    "    return hashlib.sha256(password.encode()).hexdigest()\n"
-                    "```"
-                ),
-                "answer": "Secure",
-                "language": "python",
-            },
-            # C/C++ vulnerabilities
-            {
-                "question": (
-                    "Analyze this C code:\n"
-                    "```c\n"
-                    "void read_input() {\n"
-                    "    char buffer[100];\n"
-                    "    gets(buffer);\n"
-                    '    printf("You entered: %s\\n", buffer);\n'
-                    "}\n"
-                    "```"
-                ),
-                "answer": "Vulnerable: gets() causes buffer overflow",
-                "language": "c",
-            },
-            {
-                "question": (
-                    "Review this C code:\n"
-                    "```c\n"
-                    "void copy_string(char *dest, char *src) {\n"
-                    "    strcpy(dest, src);\n"
-                    "}\n"
-                    "```"
-                ),
-                "answer": "Vulnerable: strcpy() can overflow destination buffer",
-                "language": "c",
-            },
-            {
-                "question": (
-                    "Check this C code:\n"
-                    "```c\n"
-                    "void safe_copy(char *dest, char *src, size_t n) {\n"
-                    "    strncpy(dest, src, n-1);\n"
-                    "    dest[n-1] = '\\0';\n"
-                    "}\n"
-                    "```"
-                ),
-                "answer": "Secure",
-                "language": "c",
-            },
-            # SQL injection examples
-            {
-                "question": (
-                    "Analyze this Python database code:\n"
-                    "```python\n"
-                    "def get_user(username):\n"
-                    '    query = "SELECT * FROM users WHERE name = \'" + username + "\'"\n'
-                    "    cursor.execute(query)\n"
-                    "```"
-                ),
-                "answer": "Vulnerable: SQL injection via string concatenation",
-                "language": "python",
-            },
-            {
-                "question": (
-                    "Review this code:\n"
-                    "```python\n"
-                    "def get_user_safe(username):\n"
-                    '    query = "SELECT * FROM users WHERE name = ?"\n'
-                    "    cursor.execute(query, (username,))\n"
-                    "```"
-                ),
-                "answer": "Secure",
-                "language": "python",
-            },
-            # Cryptography issues
-            {
-                "question": (
-                    "Check this encryption code:\n"
-                    "```python\n"
-                    "import random\n"
-                    "def generate_token():\n"
-                    "    return str(random.random())\n"
-                    "```"
-                ),
-                "answer": "Vulnerable: weak random number generation for tokens",
-                "language": "python",
-            },
-            {
-                "question": (
-                    "Analyze this code:\n"
-                    "```python\n"
-                    "import secrets\n"
-                    "def generate_secure_token():\n"
-                    "    return secrets.token_hex(32)\n"
-                    "```"
-                ),
-                "answer": "Secure",
-                "language": "python",
-            },
-        ]
-        # pylint: enable=line-too-long
-
-        examples.extend(code_examples[:max_examples] if max_examples else code_examples)
-        return Dataset.from_list(examples)
-
-    dataset = _create_synthetic_dataset()
-
+    dataset = _build_dataset(max_examples)
     parser = CodeVulnerabilityParser()
-
-    # Define code analysis tools
-    tools = [
-        scan_python_code,
-        scan_c_code,
-    ]
 
     rubric = vf.Rubric(
         funcs=[
-            reward_vulnerability_detection,
+            reward_patch_and_test,
             parser.get_format_reward_func(),
         ],
-        weights=[1.0, 0.3],  # Detection/fix accuracy is primary
+        weights=[1.0, 0.2],
     )
 
     if logger and logger.enabled:
         logger.log_environment_init(
             environment_name="sv-env-code-vulnerability",
-            dataset_name=dataset_name,
+            dataset_name="synthetic",
             total_examples=len(dataset),
             metadata={"max_examples": max_examples},
         )
 
     return vf.ToolEnv(
         name="sv-env-code-vulnerability",
-        description=("Inspect source code for security vulnerabilities and suggest fixes."),
+        description=(
+            "Repair vulnerable Python snippets by producing unified diff patches and running regression tests."
+        ),
         dataset=dataset,
         parser=parser,
         rubric=rubric,
-        tools=tools,
-        system_prompt=(
-            "You are a code security analyst. Inspect the provided source code for security "
-            "vulnerabilities. Use the available scanning tools when appropriate. If vulnerabilities "  # pylint: disable=line-too-long
-            "are found, explain them clearly and provide secure alternatives or fixes."
-        ),
+        tools=[run_python_static_scan, run_patch_and_tests],
+        system_prompt=textwrap.dedent(
+            """
+            You are a secure code maintainer. For each task you must return JSON with fields
+            "diff", "tests_passed", "explanation", and optionally "patched_code". Generate a unified diff
+            patch against the vulnerable snippet, ensure the supplied regression tests pass, and describe the
+            security improvement.
+            """
+        ).strip(),
     )
+
+
+__all__ = [
+    "CodeVulnerabilityParser",
+    "apply_unified_diff",
+    "load_environment",
+    "reward_patch_and_test",
+    "run_patch_and_tests",
+    "run_python_static_scan",
+]

--- a/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
+++ b/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import textwrap
 from dataclasses import dataclass
 from difflib import SequenceMatcher, unified_diff
 from pathlib import Path
+from types import MappingProxyType
 import sys
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Set
+
 from typing_extensions import TypedDict
+from unidiff import PatchSet
+from unidiff.errors import UnidiffParseError
 
 import verifiers as vf
 from datasets import Dataset
@@ -20,71 +25,165 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 from sv_shared import RolloutLogger, get_response_text  # type: ignore  # pylint: disable=wrong-import-position
 
 
-_SAFE_BUILTINS: Dict[str, Any] = {
-    "__import__": __import__,
+_BASE_SAFE_BUILTINS: Dict[str, Any] = {
     "abs": abs,
     "all": all,
     "any": any,
     "bool": bool,
     "dict": dict,
     "enumerate": enumerate,
+    "Exception": Exception,
     "float": float,
     "int": int,
+    "isinstance": isinstance,
     "len": len,
     "list": list,
+    "map": map,
     "max": max,
     "min": min,
+    "object": object,
+    "pow": pow,
+    "print": print,
     "range": range,
+    "round": round,
     "set": set,
     "sorted": sorted,
     "str": str,
     "sum": sum,
     "tuple": tuple,
     "zip": zip,
+    "ValueError": ValueError,
+    "TypeError": TypeError,
+    "AssertionError": AssertionError,
+}
+
+_ALLOWED_IMPORT_MODULES: Set[str] = {
+    "yaml",
+    "json",
+    "re",
+    "math",
+    "datetime",
+    "typing",
+}
+
+_DISALLOWED_CALLS: Set[str] = {
+    "eval",
+    "exec",
+    "open",
+    "compile",
+    "__import__",
 }
 
 
+def _restricted_import(name: str, globals_: Any | None = None, locals_: Any | None = None, fromlist=(), level: int = 0):
+    """Import hook that only allows whitelisted modules within the sandbox."""
+
+    del globals_, locals_, level
+    module_root = name.split(".")[0]
+    if module_root not in _ALLOWED_IMPORT_MODULES:
+        raise ImportError(f"Import of module '{name}' is not permitted in sandboxed execution.")
+    return __import__(name, None, None, fromlist)
+
+
+def _build_exec_globals() -> Dict[str, Any]:
+    """Construct the sandboxed globals mapping for executing patched code."""
+
+    safe_builtins = dict(_BASE_SAFE_BUILTINS)
+    safe_builtins["__import__"] = _restricted_import
+    return {
+        "__builtins__": MappingProxyType(safe_builtins),
+        "__name__": "__sandbox__",
+        "__package__": None,
+    }
+
+
+def _string_from_node(node: ast.AST) -> str | None:
+    """Return string value from AST nodes where applicable."""
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        literal_parts = [part.value for part in node.values if isinstance(part, ast.Constant)]
+        if literal_parts:
+            return "".join(literal_parts)
+    return None
+
+
+def _binop_contains_sql_concatenation(node: ast.BinOp) -> bool:
+    """Check whether a BinOp tree concatenates SQL literals with non-literal expressions."""
+
+    if not isinstance(node.op, ast.Add):
+        return False
+
+    contains_sql_literal = False
+    contains_dynamic = False
+
+    def _walk(sub_node: ast.AST) -> None:
+        nonlocal contains_sql_literal, contains_dynamic
+        if isinstance(sub_node, ast.BinOp) and isinstance(sub_node.op, ast.Add):
+            _walk(sub_node.left)
+            _walk(sub_node.right)
+            return
+
+        literal = _string_from_node(sub_node)
+        if literal is not None:
+            if "select" in literal.lower():
+                contains_sql_literal = True
+        else:
+            if not (isinstance(sub_node, ast.Constant) and isinstance(getattr(sub_node, "value", None), str)):
+                contains_dynamic = True
+
+    _walk(node)
+    return contains_sql_literal and contains_dynamic
+
+
 def apply_unified_diff(original: str, diff: str) -> Optional[str]:
-    """Apply a unified diff string to the original code."""
+    """Apply a unified diff string to the original code using a vetted parser."""
 
     if not diff.strip():
         return original
 
+    try:
+        patch = PatchSet.from_string(diff)
+    except (UnidiffParseError, TypeError):
+        return None
+
+    if len(patch) != 1:
+        return None
+
+    patched_file = patch[0]
+
     original_lines = original.splitlines()
-    diff_lines = diff.splitlines()
     patched_lines: List[str] = []
     original_index = 0
 
-    def flush_until(target_index: int) -> None:
-        nonlocal original_index
-        while original_index < min(target_index, len(original_lines)):
-            patched_lines.append(original_lines[original_index])
-            original_index += 1
+    for hunk in patched_file:
+        hunk_start = max(hunk.source_start - 1, 0)
+        if hunk_start > len(original_lines):
+            return None
 
-    for line in diff_lines:
-        if line.startswith("---") or line.startswith("+++"):
-            continue
-        if line.startswith("@@"):
-            # Unified diff hunk header format: '@@ -start,count +start,count @@'
-            try:
-                _, old_line_range, _ = line.split(" ")[:3]
-                old_start = int(old_line_range.split(",")[0][1:]) - 1
-            except (ValueError, IndexError):
-                return None
-            flush_until(old_start)
-            continue
-        if line.startswith("-"):
-            original_index += 1
-            continue
-        if line.startswith("+"):
-            patched_lines.append(line[1:])
-            continue
-        if line.startswith(" "):
-            if original_index >= len(original_lines):
-                return None
-            patched_lines.append(original_lines[original_index])
-            original_index += 1
-    flush_until(len(original_lines))
+        patched_lines.extend(original_lines[original_index:hunk_start])
+        original_index = hunk_start
+
+        for line in hunk:
+            if line.line_type == "\\":
+                continue
+
+            value = line.value.rstrip("\n")
+
+            if line.is_context:
+                if original_index >= len(original_lines) or original_lines[original_index] != value:
+                    return None
+                patched_lines.append(value)
+                original_index += 1
+            elif line.is_removed:
+                if original_index >= len(original_lines) or original_lines[original_index] != value:
+                    return None
+                original_index += 1
+            elif line.is_added:
+                patched_lines.append(value)
+
+    patched_lines.extend(original_lines[original_index:])
 
     return "\n".join(patched_lines)
 
@@ -111,6 +210,65 @@ def _normalize_query_result(result: Any) -> Any:
     return result
 
 
+def _validate_patched_code(patched_code: str) -> None:
+    """Ensure patched code obeys sandbox constraints before execution."""
+
+    try:
+        tree = ast.parse(patched_code)
+    except SyntaxError as exc:  # pragma: no cover - invalid syntax handled elsewhere
+        raise ValueError(f"Patched code is not valid Python: {exc.msg}") from exc
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                module_root = alias.name.split(".")[0]
+                if module_root not in _ALLOWED_IMPORT_MODULES:
+                    raise ValueError(f"Import of module '{alias.name}' is not permitted in sandboxed execution.")
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            module_root = module.split(".")[0]
+            if module_root not in _ALLOWED_IMPORT_MODULES:
+                module_name = module or "<relative>"
+                raise ValueError(
+                    f"Import from module '{module_name}' is not permitted in sandboxed execution."
+                )
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id in _DISALLOWED_CALLS:
+                raise ValueError(f"Call to '{node.func.id}' is not permitted in sandboxed execution.")
+
+
+def _detect_sql_injection_patterns(code: str) -> Optional[str]:
+    """Return a descriptive finding if SQL string concatenation patterns are detected."""
+
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        code_lower = code.lower()
+        if "select" in code_lower and (".format" in code_lower or "%" in code or "{" in code and "}" in code):
+            return "SQL injection risk: query string appears to interpolate user-controlled data."
+        return None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.BinOp) and _binop_contains_sql_concatenation(node):
+            return "SQL injection risk: query string uses string concatenation without parameters."
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+            left_literal = _string_from_node(node.left)
+            if left_literal and "select" in left_literal.lower():
+                return "SQL injection risk: query string uses printf-style formatting without parameters."
+        elif isinstance(node, ast.JoinedStr):
+            literal = _string_from_node(node)
+            has_formatted = any(isinstance(part, ast.FormattedValue) for part in node.values)
+            if literal and "select" in literal.lower() and has_formatted:
+                return "SQL injection risk: query constructed via f-string interpolation."
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "format":
+                literal = _string_from_node(node.func.value)
+                if literal and "select" in literal.lower() and node.args:
+                    return "SQL injection risk: query string uses str.format without parameters."
+
+    return None
+
+
 def _execute_behavioral_test(func: Any, case: Dict[str, Any], category: str, failures: List[str]) -> None:
     args = case.get("args", [])
     kwargs = case.get("kwargs", {})
@@ -132,8 +290,8 @@ def _execute_behavioral_test(func: Any, case: Dict[str, Any], category: str, fai
             if isinstance(exc, expected_exceptions):
                 return
             raise RuntimeError(
-                "Unexpected exception %s during test execution for %s with input %s: %s"
-                % (exc.__class__.__name__, category, args, exc)
+                f"Unexpected exception {exc.__class__.__name__} during test execution for {category} "
+                f"with input {args}: {exc}"
             ) from exc
         failures.append(f"{category}: expected an exception for input {args} but none was raised.")
         return
@@ -213,9 +371,37 @@ def run_patch_and_tests(
             "details": [],
         }
 
-    exec_globals: Dict[str, Any] = {"__builtins__": dict(_SAFE_BUILTINS)}
-    code_obj = compile(patched_code, "<patched_code>", "exec")
-    exec(code_obj, exec_globals)  # noqa: S102 - deliberate execution of trusted dataset code
+    try:
+        _validate_patched_code(patched_code)
+    except ValueError as exc:
+        return {
+            "patched_code": patched_code,
+            "tests_passed": False,
+            "failures": [str(exc)],
+            "details": [],
+        }
+
+    exec_globals = _build_exec_globals()
+
+    try:
+        code_obj = compile(patched_code, "<patched_code>", "exec")
+    except SyntaxError as exc:
+        return {
+            "patched_code": patched_code,
+            "tests_passed": False,
+            "failures": [f"Patched code failed to compile: {exc.msg}"],
+            "details": [],
+        }
+
+    try:
+        exec(code_obj, exec_globals)  # noqa: S102 - deliberate execution of trusted dataset code
+    except Exception as exc:  # noqa: BLE001 - sandbox errors surfaced to caller
+        return {
+            "patched_code": patched_code,
+            "tests_passed": False,
+            "failures": [f"Patched code raised {exc.__class__.__name__}: {exc}"],
+            "details": [],
+        }
 
     entrypoint = spec_dict.get("entrypoint")
     func = exec_globals.get(entrypoint)
@@ -255,13 +441,13 @@ def run_patch_and_tests(
 def run_python_static_scan(code: str) -> Dict[str, Any]:
     """Simple heuristic static analysis for Python snippets."""
 
-    code_lower = code.lower()
     vulnerabilities: List[str] = []
 
-    if "select" in code_lower and (
-        "%" in code or ".format" in code_lower or "{" in code and "}" in code or "+" in code_lower
-    ):
-        vulnerabilities.append("SQL injection risk: query string uses concatenation/formatting without parameters.")
+    sql_issue = _detect_sql_injection_patterns(code)
+    if sql_issue:
+        vulnerabilities.append(sql_issue)
+
+    code_lower = code.lower()
 
     if "yaml.load" in code_lower and "safe_load" not in code_lower:
         vulnerabilities.append("Unsafe YAML loading: yaml.load without SafeLoader exposes arbitrary object execution.")

--- a/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
+++ b/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
@@ -20,6 +20,30 @@ sys.path.append(str(Path(__file__).resolve().parents[2]))
 from sv_shared import RolloutLogger, get_response_text  # type: ignore  # pylint: disable=wrong-import-position
 
 
+_SAFE_BUILTINS: Dict[str, Any] = {
+    "__import__": __import__,
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bool": bool,
+    "dict": dict,
+    "enumerate": enumerate,
+    "float": float,
+    "int": int,
+    "len": len,
+    "list": list,
+    "max": max,
+    "min": min,
+    "range": range,
+    "set": set,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "zip": zip,
+}
+
+
 def apply_unified_diff(original: str, diff: str) -> Optional[str]:
     """Apply a unified diff string to the original code."""
 
@@ -41,9 +65,10 @@ def apply_unified_diff(original: str, diff: str) -> Optional[str]:
         if line.startswith("---") or line.startswith("+++"):
             continue
         if line.startswith("@@"):
+            # Unified diff hunk header format: '@@ -start,count +start,count @@'
             try:
-                _, old_range, _ = line.split(" ")[:3]
-                old_start = int(old_range.split(",")[0][1:]) - 1
+                _, old_line_range, _ = line.split(" ")[:3]
+                old_start = int(old_line_range.split(",")[0][1:]) - 1
             except (ValueError, IndexError):
                 return None
             flush_until(old_start)
@@ -96,37 +121,41 @@ def _execute_behavioral_test(func: Any, case: Dict[str, Any], category: str, fai
     if expects_exception:
         try:
             func(*args, **kwargs)
-        except Exception:  # noqa: broad-except - used for sandboxed tests
-            return
-        failures.append(
-            f"{category}: expected an exception for input {args} but none was raised."
-        )
+        except Exception as exc:  # noqa: BLE001 - inspect to re-raise unexpected issues
+            expected_exceptions = (
+                ImportError,
+                NameError,
+                TypeError,
+                ValueError,
+                AssertionError,
+            )
+            if isinstance(exc, expected_exceptions):
+                return
+            raise RuntimeError(
+                "Unexpected exception %s during test execution for %s with input %s: %s"
+                % (exc.__class__.__name__, category, args, exc)
+            ) from exc
+        failures.append(f"{category}: expected an exception for input {args} but none was raised.")
         return
 
     try:
         result = func(*args, **kwargs)
-    except Exception as exc:  # noqa: broad-except - bubble up failure context
-        failures.append(
-            f"{category}: call with {args} raised {exc.__class__.__name__}: {exc}"
-        )
+    except Exception as exc:  # noqa: BLE001 - we record context for the caller
+        failures.append(f"{category}: call with {args} raised {exc.__class__.__name__}: {exc}")
         return
 
     if expected is not None:
         normalized_expected = _normalize_query_result(expected)
         normalized_result = _normalize_query_result(result)
         if normalized_expected != normalized_result:
-            failures.append(
-                f"{category}: expected {normalized_expected} but received {normalized_result}"
-            )
+            failures.append(f"{category}: expected {normalized_expected} but received {normalized_result}")
 
 
 def _check_code_properties(patched_code: str, spec: Dict[str, Any], failures: List[str]) -> None:
     for substring in spec.get("required_substrings_in_code", []):
         if substring not in patched_code:
             if substring == "?":
-                failures.append(
-                    "Patched code missing required '?' placeholder for parameterized queries."
-                )
+                failures.append("Patched code missing required '?' placeholder for parameterized queries.")
             else:
                 failures.append(f"Patched code missing required token '{substring}'.")
 
@@ -184,11 +213,12 @@ def run_patch_and_tests(
             "details": [],
         }
 
-    namespace: Dict[str, Any] = {}
-    exec(patched_code, namespace)  # noqa: S102 - deliberate execution of trusted dataset code
+    exec_globals: Dict[str, Any] = {"__builtins__": dict(_SAFE_BUILTINS)}
+    code_obj = compile(patched_code, "<patched_code>", "exec")
+    exec(code_obj, exec_globals)  # noqa: S102 - deliberate execution of trusted dataset code
 
     entrypoint = spec_dict.get("entrypoint")
-    func = namespace.get(entrypoint)
+    func = exec_globals.get(entrypoint)
 
     if not callable(func):
         return {
@@ -201,10 +231,16 @@ def run_patch_and_tests(
     failures: List[str] = []
 
     for case in spec_dict.get("behavioral_tests", []):
-        _execute_behavioral_test(func, case, "Behavioral", failures)
+        try:
+            _execute_behavioral_test(func, case, "Behavioral", failures)
+        except RuntimeError as exc:  # Surface unexpected sandbox errors to the caller
+            failures.append(str(exc))
 
     for case in spec_dict.get("security_tests", []):
-        _execute_behavioral_test(func, case, "Security", failures)
+        try:
+            _execute_behavioral_test(func, case, "Security", failures)
+        except RuntimeError as exc:
+            failures.append(str(exc))
 
     _check_code_properties(patched_code, spec_dict, failures)
 
@@ -223,24 +259,15 @@ def run_python_static_scan(code: str) -> Dict[str, Any]:
     vulnerabilities: List[str] = []
 
     if "select" in code_lower and (
-        "%" in code
-        or ".format" in code_lower
-        or "{" in code and "}" in code
-        or "+" in code_lower
+        "%" in code or ".format" in code_lower or "{" in code and "}" in code or "+" in code_lower
     ):
-        vulnerabilities.append(
-            "SQL injection risk: query string uses concatenation/formatting without parameters."
-        )
+        vulnerabilities.append("SQL injection risk: query string uses concatenation/formatting without parameters.")
 
     if "yaml.load" in code_lower and "safe_load" not in code_lower:
-        vulnerabilities.append(
-            "Unsafe YAML loading: yaml.load without SafeLoader exposes arbitrary object execution."
-        )
+        vulnerabilities.append("Unsafe YAML loading: yaml.load without SafeLoader exposes arbitrary object execution.")
 
     if "random" in code_lower and "token" in code_lower and "secrets" not in code_lower:
-        vulnerabilities.append(
-            "Insecure randomness: prefer secrets.token_hex for security tokens."
-        )
+        vulnerabilities.append("Insecure randomness: prefer secrets.token_hex for security tokens.")
 
     return {
         "language": "python",
@@ -352,12 +379,7 @@ def reward_patch_and_test(
     else:
         explanation_score = 1.0 if explanation.strip() else 0.0
 
-    base_reward = (
-        0.6 * tests_score
-        + 0.2 * diff_similarity
-        + 0.1 * consistency_score
-        + 0.1 * explanation_score
-    )
+    base_reward = 0.6 * tests_score + 0.2 * diff_similarity + 0.1 * consistency_score + 0.1 * explanation_score
 
     if not actual_tests_passed and patch_result.get("failures"):
         base_reward = max(0.0, base_reward - 0.1)
@@ -544,10 +566,7 @@ def _build_dataset(max_examples: int | None = None) -> Dataset:
     if max_examples is not None:
         examples = examples[:max_examples]
 
-    dataset_dicts = [
-        {"question": example.question, "answer": example.answer}
-        for example in examples
-    ]
+    dataset_dicts = [{"question": example.question, "answer": example.answer} for example in examples]
 
     return Dataset.from_list(dataset_dicts)
 

--- a/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
+++ b/environments/sv-env-code-vulnerability/sv_env_code_vulnerability.py
@@ -10,7 +10,7 @@ from difflib import SequenceMatcher, unified_diff
 from pathlib import Path
 from types import MappingProxyType
 import sys
-from typing import Any, Dict, Iterable, List, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from typing_extensions import TypedDict
 from unidiff import PatchSet
@@ -73,6 +73,14 @@ _DISALLOWED_CALLS: Set[str] = {
     "compile",
     "__import__",
 }
+
+_EXPECTED_SANDBOX_EXCEPTIONS: Tuple[type[Exception], ...] = (
+    ImportError,
+    NameError,
+    TypeError,
+    ValueError,
+    AssertionError,
+)
 
 
 def _restricted_import(name: str, globals_: Any | None = None, locals_: Any | None = None, fromlist=(), level: int = 0):
@@ -216,7 +224,7 @@ def _validate_patched_code(patched_code: str) -> None:
     try:
         tree = ast.parse(patched_code)
     except SyntaxError as exc:  # pragma: no cover - invalid syntax handled elsewhere
-        raise ValueError(f"Patched code is not valid Python: {exc.msg}") from exc
+        raise ValueError(f"Patched code is not valid Python: {exc}") from exc
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -229,9 +237,7 @@ def _validate_patched_code(patched_code: str) -> None:
             module_root = module.split(".")[0]
             if module_root not in _ALLOWED_IMPORT_MODULES:
                 module_name = module or "<relative>"
-                raise ValueError(
-                    f"Import from module '{module_name}' is not permitted in sandboxed execution."
-                )
+                raise ValueError(f"Import from module '{module_name}' is not permitted in sandboxed execution.")
         elif isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name) and node.func.id in _DISALLOWED_CALLS:
                 raise ValueError(f"Call to '{node.func.id}' is not permitted in sandboxed execution.")
@@ -280,14 +286,7 @@ def _execute_behavioral_test(func: Any, case: Dict[str, Any], category: str, fai
         try:
             func(*args, **kwargs)
         except Exception as exc:  # noqa: BLE001 - inspect to re-raise unexpected issues
-            expected_exceptions = (
-                ImportError,
-                NameError,
-                TypeError,
-                ValueError,
-                AssertionError,
-            )
-            if isinstance(exc, expected_exceptions):
+            if isinstance(exc, _EXPECTED_SANDBOX_EXCEPTIONS):
                 return
             raise RuntimeError(
                 f"Unexpected exception {exc.__class__.__name__} during test execution for {category} "
@@ -389,7 +388,7 @@ def run_patch_and_tests(
         return {
             "patched_code": patched_code,
             "tests_passed": False,
-            "failures": [f"Patched code failed to compile: {exc.msg}"],
+            "failures": [f"Patched code failed to compile: {exc}"],
             "details": [],
         }
 

--- a/environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py
+++ b/environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py
@@ -166,6 +166,15 @@ def test_python_static_scan_detects_injection(sql_injection_example: dict) -> No
     assert any("SQL" in finding for finding in report["vulnerabilities"])
 
 
+def test_python_static_scan_allows_parameterized(sql_injection_example: dict) -> None:
+    """Static scan should not raise false positives for parameterized queries."""
+
+    report = run_python_static_scan(sql_injection_example["patched_code"])
+
+    assert report["verdict"] == "Secure"
+    assert report["vulnerabilities_found"] == 0
+
+
 def test_apply_unified_diff_round_trip(sql_injection_example: dict) -> None:
     """Applying the diff should recreate the patched code."""
 
@@ -176,6 +185,14 @@ def test_apply_unified_diff_round_trip(sql_injection_example: dict) -> None:
 
     assert patched is not None
     assert patched.strip() == sql_injection_example["patched_code"].strip()
+
+
+def test_apply_unified_diff_rejects_invalid_patch(sql_injection_example: dict) -> None:
+    """Invalid diff strings should not be applied."""
+
+    patched = apply_unified_diff(sql_injection_example["original_code"], "not a diff")
+
+    assert patched is None
 
 
 def test_run_patch_and_tests_success(sql_injection_example: dict) -> None:
@@ -202,6 +219,21 @@ def test_run_patch_and_tests_failure(sql_injection_example: dict) -> None:
 
     assert result["tests_passed"] is False
     assert any("parameterized" in failure.lower() for failure in result["failures"])
+
+
+def test_run_patch_and_tests_blocks_forbidden_import(sql_injection_example: dict) -> None:
+    """Sandbox should reject patched code importing disallowed modules."""
+
+    malicious_code = "import os\n" + sql_injection_example["patched_code"]
+
+    result = run_patch_and_tests(
+        original_code=sql_injection_example["original_code"],
+        patched_code=malicious_code,
+        test_spec=sql_injection_example["test_spec"],
+    )
+
+    assert result["tests_passed"] is False
+    assert any("Import of module" in failure for failure in result["failures"])
 
 
 def test_parser_parses_and_rewards_format(sql_injection_example: dict) -> None:

--- a/environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py
+++ b/environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py
@@ -1,144 +1,287 @@
-"""Tests for the code vulnerability environment."""
+"""Tests for the sv-env-code-vulnerability environment."""
 
+from __future__ import annotations
+
+import difflib
+import json
+import textwrap
+
+import pytest
 import verifiers as vf
+
 from sv_env_code_vulnerability import (
     CodeVulnerabilityParser,
+    apply_unified_diff,
     load_environment,
-    reward_vulnerability_detection,
-    scan_c_code,
-    scan_python_code,
+    reward_patch_and_test,
+    run_patch_and_tests,
+    run_python_static_scan,
 )
 
 
-class TestCodeVulnerabilityParser:
-    """Test cases for CodeVulnerabilityParser class."""
+@pytest.fixture
+def sql_injection_example() -> dict:
+    """Example dataset entry for SQL injection mitigation."""
 
-    def test_parse_answer_vulnerable(self):
-        """Test parsing vulnerable responses."""
-        parser = CodeVulnerabilityParser()
-        assert parser.parse_answer("Vulnerable") == "Vulnerable"
-        assert parser.parse_answer("Code has vulnerability") == "Vulnerable"
-        assert parser.parse_answer("Security vulnerability detected") == "Vulnerable"
+    vulnerable_code = textwrap.dedent(
+        '''
+        def build_query(username: str) -> str:
+            """Return a SQL query for the supplied username."""
 
-    def test_parse_answer_secure(self):
-        """Test parsing secure responses."""
-        parser = CodeVulnerabilityParser()
-        assert parser.parse_answer("Secure") == "Secure"
-        assert parser.parse_answer("Code is secure") == "Secure"
+            return f"SELECT * FROM users WHERE name = '{username}'"
+        '''
+    ).strip()
 
-    def test_parse_answer_fixed(self):
-        """Test parsing fixed responses."""
-        parser = CodeVulnerabilityParser()
-        assert parser.parse_answer("Fixed") == "Fixed"
-        assert parser.parse_answer("Vulnerability has been fixed") == "Fixed"
+    patched_code = textwrap.dedent(
+        '''
+        def build_query(username: str) -> tuple[str, tuple[str, ...]]:
+            """Return a parameterized SQL query and parameters."""
 
-    def test_format_reward(self):
-        """Test format reward function."""
-        parser = CodeVulnerabilityParser()
-        format_func = parser.get_format_reward_func()
+            query = "SELECT * FROM users WHERE name = ?"
+            params = (username,)
+            return query, params
+        '''
+    ).strip()
 
-        # Perfect format
-        assert format_func("Vulnerable: buffer overflow. Fix: use strncpy instead") == 1.0
+    diff = "\n".join(
+        difflib.unified_diff(
+            vulnerable_code.splitlines(),
+            patched_code.splitlines(),
+            fromfile="query.py",
+            tofile="query.py",
+            lineterm="",
+        )
+    )
 
-        # Partial format
-        assert format_func("This code is vulnerable") == 0.5
-
-        # Poor format
-        assert format_func("I don't know") == 0.0
-
-
-def test_scan_python_code_vulnerable():
-    """Test Python code scanner with vulnerable code."""
-    code = """
-    def process_user_input(data):
-        result = eval(data)
-        exec(data)
-        os.system("rm -rf " + data)
-    """
-
-    result = scan_python_code(code)
-
-    assert result["language"] == "Python"
-    assert result["verdict"] == "Vulnerable"
-    assert result["vulnerabilities_found"] >= 2
-    assert any("eval()" in vuln for vuln in result["vulnerabilities"])
-
-
-def test_scan_python_code_secure():
-    """Test Python code scanner with secure code."""
-    code = """
-    import hashlib
-    def hash_password(password):
-        salt = os.urandom(32)
-        return hashlib.pbkdf2_hmac('sha256', password.encode(), salt, 100000)
-    """
-
-    result = scan_python_code(code)
-
-    assert result["language"] == "Python"
-    assert result["verdict"] == "Secure"
-    assert result["vulnerabilities_found"] == 0
-
-
-def test_scan_c_code_vulnerable():
-    """Test C code scanner with vulnerable code."""
-    code = """
-    void read_input() {
-        char buffer[100];
-        gets(buffer);
-        strcpy(buffer, user_input);
-        system(buffer);
+    test_spec = {
+        "entrypoint": "build_query",
+        "behavioral_tests": [
+            {
+                "args": ["alice"],
+                "expected": {
+                    "query": "SELECT * FROM users WHERE name = ?",
+                    "params": ("alice",),
+                },
+            }
+        ],
+        "security_tests": [
+            {
+                "args": ["bob' OR '1'='1"],
+                "expected": {
+                    "query": "SELECT * FROM users WHERE name = ?",
+                    "params": ("bob' OR '1'='1",),
+                },
+            }
+        ],
+        "required_substrings_in_code": ["?"],
+        "forbidden_substrings_in_code": ["%", "+"],
     }
-    """
 
-    result = scan_c_code(code)
-
-    assert result["language"] == "C/C++"
-    assert result["verdict"] == "Vulnerable"
-    assert result["vulnerabilities_found"] >= 3
-    assert any("gets()" in vuln for vuln in result["vulnerabilities"])
-
-
-def test_scan_c_code_secure():
-    """Test C code scanner with secure code."""
-    code = """
-    void safe_copy(char *dest, char *src, size_t size) {
-        strncpy(dest, src, size - 1);
-        dest[size - 1] = '\\0';
+    return {
+        "id": "sql_injection_parameterization",
+        "language": "python",
+        "original_code": vulnerable_code,
+        "patched_code": patched_code,
+        "expected_diff": diff,
+        "test_spec": test_spec,
+        "expected_tests_passed": True,
+        "explanation_keywords": ["parameterized", "parameters"],
     }
-    """
-
-    result = scan_c_code(code)
-
-    assert result["language"] == "C/C++"
-    assert result["verdict"] == "Secure"
-    assert result["vulnerabilities_found"] == 0
 
 
-def test_reward_vulnerability_detection():
-    """Test vulnerability detection reward function."""
-    # Correct detection with tools
-    completion = "Vulnerable: eval() allows code injection. Fix: use ast.literal_eval"
-    answer = "Vulnerable: eval() allows arbitrary code execution"
-    tools_used = ["scan_python_code"]
+@pytest.fixture
+def unsafe_yaml_example() -> dict:
+    """Example dataset entry for unsafe YAML loading mitigation."""
 
-    reward = reward_vulnerability_detection(completion, answer, tools_used)
-    assert reward > 0.7  # Should get high reward
-
-    # Correct secure assessment
-    completion = "Code is secure, no vulnerabilities found"
-    answer = "Secure"
-
-    reward = reward_vulnerability_detection(completion, answer)
-    assert reward > 0.0
+    vulnerable_code = textwrap.dedent(
+        '''
+        import yaml
 
 
-def test_load_environment():
-    """Test loading the code vulnerability environment."""
-    env = load_environment(max_examples=5)
+        def load_config(document: str):
+            """Load YAML configuration without safety checks."""
+
+            return yaml.load(document, Loader=yaml.FullLoader)
+        '''
+    ).strip()
+
+    patched_code = textwrap.dedent(
+        '''
+        import yaml
+
+
+        def load_config(document: str):
+            """Safely load YAML configuration using safe_load."""
+
+            return yaml.safe_load(document)
+        '''
+    ).strip()
+
+    diff = "\n".join(
+        difflib.unified_diff(
+            vulnerable_code.splitlines(),
+            patched_code.splitlines(),
+            fromfile="config.py",
+            tofile="config.py",
+            lineterm="",
+        )
+    )
+
+    test_spec = {
+        "entrypoint": "load_config",
+        "behavioral_tests": [
+            {
+                "args": ["debug: false"],
+                "expected": {"debug": False},
+            }
+        ],
+        "security_tests": [
+            {
+                "args": ["!!python/object/apply:os.system ['echo unsafe']"],
+                "raises": True,
+            }
+        ],
+        "required_substrings_in_code": ["safe_load"],
+        "forbidden_substrings_in_code": ["yaml.load"],
+    }
+
+    return {
+        "id": "yaml_safe_load",
+        "language": "python",
+        "original_code": vulnerable_code,
+        "patched_code": patched_code,
+        "expected_diff": diff,
+        "test_spec": test_spec,
+        "expected_tests_passed": True,
+        "explanation_keywords": ["safe_load", "unsafe", "yaml"],
+    }
+
+
+def test_python_static_scan_detects_injection(sql_injection_example: dict) -> None:
+    """Static scan should flag SQL string concatenation vulnerabilities."""
+
+    report = run_python_static_scan(sql_injection_example["original_code"])
+
+    assert report["verdict"] == "Vulnerable"
+    assert any("SQL" in finding for finding in report["vulnerabilities"])
+
+
+def test_apply_unified_diff_round_trip(sql_injection_example: dict) -> None:
+    """Applying the diff should recreate the patched code."""
+
+    patched = apply_unified_diff(
+        sql_injection_example["original_code"],
+        sql_injection_example["expected_diff"],
+    )
+
+    assert patched is not None
+    assert patched.strip() == sql_injection_example["patched_code"].strip()
+
+
+def test_run_patch_and_tests_success(sql_injection_example: dict) -> None:
+    """Patch runner should execute behavioral and security tests."""
+
+    result = run_patch_and_tests(
+        original_code=sql_injection_example["original_code"],
+        diff=sql_injection_example["expected_diff"],
+        test_spec=sql_injection_example["test_spec"],
+    )
+
+    assert result["tests_passed"] is True
+    assert result["failures"] == []
+
+
+def test_run_patch_and_tests_failure(sql_injection_example: dict) -> None:
+    """Supplying the vulnerable code should cause the tests to fail."""
+
+    result = run_patch_and_tests(
+        original_code=sql_injection_example["original_code"],
+        patched_code=sql_injection_example["original_code"],
+        test_spec=sql_injection_example["test_spec"],
+    )
+
+    assert result["tests_passed"] is False
+    assert any("parameterized" in failure.lower() for failure in result["failures"])
+
+
+def test_parser_parses_and_rewards_format(sql_injection_example: dict) -> None:
+    """Parser should extract JSON fields and format reward should reflect compliance."""
+
+    parser = CodeVulnerabilityParser()
+
+    completion = json.dumps(
+        {
+            "diff": sql_injection_example["expected_diff"],
+            "tests_passed": True,
+            "explanation": "The query is now parameterized using placeholders and parameters.",
+            "patched_code": sql_injection_example["patched_code"],
+        }
+    )
+
+    parsed = parser.parse_answer(completion)
+
+    assert parsed["tests_passed"] is True
+    assert "parameterized" in parsed["explanation"].lower()
+
+    format_reward = parser.get_format_reward_func()
+    assert format_reward(completion) == 1.0
+    assert format_reward("not json") == 0.0
+
+
+def test_reward_patch_and_test(sql_injection_example: dict) -> None:
+    """Reward should be high for correct fixes and low for incorrect ones."""
+
+    good_completion = json.dumps(
+        {
+            "diff": sql_injection_example["expected_diff"],
+            "tests_passed": True,
+            "explanation": "The query is parameterized and avoids direct string concatenation.",
+            "patched_code": sql_injection_example["patched_code"],
+        }
+    )
+
+    reward = reward_patch_and_test(good_completion, sql_injection_example)
+    assert reward > 0.8
+
+    bad_completion = json.dumps(
+        {
+            "diff": "",
+            "tests_passed": True,
+            "explanation": "Everything is already safe.",
+            "patched_code": sql_injection_example["original_code"],
+        }
+    )
+
+    bad_reward = reward_patch_and_test(bad_completion, sql_injection_example)
+    assert bad_reward < 0.4
+
+
+def test_reward_handles_security_regressions(unsafe_yaml_example: dict) -> None:
+    """Reward function should penalize patches that keep unsafe loaders."""
+
+    regression_completion = json.dumps(
+        {
+            "diff": unsafe_yaml_example["expected_diff"],
+            "tests_passed": True,
+            "explanation": "yaml.safe_load is used to avoid executing arbitrary objects.",
+            "patched_code": unsafe_yaml_example["original_code"],
+        }
+    )
+
+    reward = reward_patch_and_test(regression_completion, unsafe_yaml_example)
+    assert reward < 0.5
+
+
+def test_load_environment_creates_tool_env() -> None:
+    """Environment loader should assemble dataset, tools, and rubric."""
+
+    env = load_environment(max_examples=2)
 
     assert isinstance(env, vf.ToolEnv)
-    assert env.dataset is not None
-    assert len(env.dataset) == 5
-    assert env.tools is not None
-    assert len(env.tools) == 2  # Python and C scanners
+    assert len(env.dataset) == 2
+    example = env.dataset[0]
+
+    assert "diff" in env.system_prompt.lower()
+    assert isinstance(example["answer"], dict)
+    assert "test_spec" in example["answer"]
+    assert len(env.tools) == 2


### PR DESCRIPTION
## Summary
- replace the stubbed code vulnerability scaffold with a patch-and-test ToolEnv, parser, heuristic static scan, and dataset builders
- add executable regression tests and reward shaping that score patches based on diff quality, test execution, and explanation coverage
- document the environment workflow and interfaces in the package README and a new docs/sv-env-code-vulnerability guide

## Testing
- uv run pytest environments/sv-env-code-vulnerability/sv_env_code_vulnerability_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d60ab0fdd083249934b57ea3fa5330

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a sandboxed patch-and-test environment that applies unified diffs to vulnerable Python snippets, runs regression tests, scores patches, and documents/tests the workflow.
> 
> - **Environment**:
>   - Replace detection-only scaffold with patch-and-test `vf.ToolEnv` executing unified diffs against vulnerable snippets.
>   - Sandboxed execution with restricted builtins/imports and AST validation; disallowed calls enforced.
>   - New dataset builders (SQL parameterization, safe YAML loading) loaded via `datasets.Dataset`.
> - **Tools**:
>   - `run_patch_and_tests`: applies diff/full code, validates sandbox rules, runs behavioral/security tests, returns structured `PatchTestResult`.
>   - `run_python_static_scan`: heuristic SAST for SQL concat, unsafe YAML, insecure randomness.
> - **Parser & Reward**:
>   - `CodeVulnerabilityParser` now enforces JSON schema (`diff`, `tests_passed`, `explanation`, optional `patched_code`).
>   - `reward_patch_and_test`: combines test pass (60%), diff similarity (20%), consistency (10%), explanation coverage (10%).
> - **Diff Handling**:
>   - `apply_unified_diff` using `unidiff.PatchSet`; rejects malformed/multi-file patches.
> - **Testing**:
>   - Comprehensive tests for parser, static scan, diff application, patch executor success/failure, reward shaping, env loader wiring.
> - **Docs**:
>   - New `docs/sv-env-code-vulnerability.md` and revamped package `README.md` detailing schema, tools, reward, dataset, sandbox, and usage.
> - **Dependencies**:
>   - Add `unidiff` to `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dd42d9052e0224fa8e446ae312c376629413dbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->