### PR TITLE
Update documentation to reflect current environment behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ Security Verifiers uses a dual-mode logging system:
 
   - scripts/eval_network_logs.py, scripts/eval_config_verification.py, scripts/eval_config_verification_singleturn.py write run metadata + per-example results under outputs/evals/sv-env-{name}--{model}/{run_id}/{metadata.json,results.jsonl}
   - All evaluation scripts support early stopping via --max-consecutive-errors (default: 3) to prevent wasted API costs on misconfigured models
-  - E2 uses multi-turn evaluation by default, enabling models to call tools (kube-linter, semgrep, OPA) and achieve ~0.93 reward with tools vs ~0.62 without
+  - E2 uses multi-turn evaluation by default, enabling models to call tools (kube-linter, semgrep, OPA) and typically improving rewards compared to tool-free runs
   - scripts/model_router.py provides robust model name resolution: (1) fetches live models from OpenRouter API with 24h caching, (2) fuzzy-matches shorthand names (e.g., qwen3-14b → qwen/qwen3-14b), (3) falls back to hardcoded mappings when offline, (4) supports any OpenRouter model without code changes
 
 - CI

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Before using any of the security verification environments, you need to set up y
    # Get your key at: https://openrouter.ai/keys
    OPENROUTER_API_KEY=your-openrouter-api-key-here
 
-   # Required for logging: Weights & Biases API Key
+    # Required for Weave/W&B logging: Weights & Biases API Key
    # Sign up free at: https://wandb.ai
    # Get your key at: https://wandb.ai/authorize
    WANDB_API_KEY=your-wandb-api-key-here
@@ -300,11 +300,11 @@ uv run pre-commit run --all-files
 | Environment                  | Type                  | Reward Focus                                   | Key Innovation                            |
 | ---------------------------- | --------------------- | ---------------------------------------------- | ----------------------------------------- |
 | `sv-env-network-logs`        | SingleTurnEnv         | Calibration, abstention, asymmetric costs      | Operational SOC metrics over raw accuracy |
-| `sv-env-phishing-detection`  | SingleTurnEnv         | Evidence-seeking, FN penalties                 | Tool-calling for URL/domain reputation    |
+| `sv-env-phishing-detection`  | SingleTurnEnv         | Evidence-seeking, FN penalties                 | URL heuristics with structured evidence   |
 | `sv-env-config-verification` | ToolEnv               | Machine-verified fixes with patch verification | OPA/Rego/KubeLinter/Semgrep ground truth  |
-| `sv-env-code-vulnerability`  | MultiTurnEnv          | Test-passing, minimal diffs                    | Executable verification loop              |
+| `sv-env-code-vulnerability`  | ToolEnv               | Test-passing, minimal diffs                    | Executable verification loop              |
 | `sv-env-redteam-attack`      | MultiTurnEnv          | Unsafe elicitation success                     | Llama Guard 3 safety scoring              |
-| `sv-env-redteam-defense`     | SingleTurnEnv (alpha) | Helpful/harmless balance                       | Co-training with attacker agent           |
+| `sv-env-redteam-defense`     | SingleTurnEnv (alpha) | Helpful/harmless balance                       | Synthetic refusal curriculum & safety heuristics |
 
 ## Shared Toolbox
 

--- a/WARP.md
+++ b/WARP.md
@@ -145,7 +145,7 @@ Security Verifiers uses a dual-mode logging system:
 
   - scripts/eval_network_logs.py, scripts/eval_config_verification.py, scripts/eval_config_verification_singleturn.py write run metadata + per-example results under outputs/evals/sv-env-{name}--{model}/{run_id}/{metadata.json,results.jsonl}
   - All evaluation scripts support early stopping via --max-consecutive-errors (default: 3) to prevent wasted API costs
-  - E2 uses multi-turn evaluation by default, enabling models to call tools (kube-linter, semgrep, OPA) and achieve ~0.93 reward with tools vs ~0.62 without
+  - E2 uses multi-turn evaluation by default, enabling models to call tools (kube-linter, semgrep, OPA) and typically improving rewards compared to runs without tool access
   - scripts/model_router.py: Robust model routing with OpenRouter API auto-discovery, fuzzy matching, and offline fallbacks
 
 - CI


### PR DESCRIPTION
## Summary
- clarify the README environment table so the phishing, code-vulnerability, and redteam-defense rows match their current implementations
- note that the Weights & Biases key is needed specifically for Weave/W&B logging flows
- align AGENTS and WARP guidance with the current tool-enabled evaluation behaviour without outdated reward claims

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f4b513706083248840c6d2dfbdfa60